### PR TITLE
Add script for creating a Django superuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ management commands in the docker web container:
 * `./manage.py import_mps`
 
 You can then view it at (http://localhost:8000/)
+
+You can create the first Django user by entering a bash shell inside the `web` container, and then running the `createsuperuser` script through the Django shell:
+
+    docker-compose exec web bash
+    script/createsuperuser
+
+The superuser will be created with the details specified in the `DJANGO_SUPERUSER_*` environment variables. [Read more about how Docker handles environment variables](https://docs.docker.com/compose/envvars-precedence/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       EMAIL_HOST: email.svc
       CACHE_FILE: 'data/cache'
       MAPIT_URL: 'https://mapit.mysociety.org/'
+      DJANGO_SUPERUSER_USERNAME: 'admin'
+      DJANGO_SUPERUSER_PASSWORD: 'password'
+      DJANGO_SUPERUSER_EMAIL: 'admin@localhost'
   mailhog:
     image: mailhog/mailhog:v1.0.1
     restart: always

--- a/script/createsuperuser
+++ b/script/createsuperuser
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# abort on any errors
+set -e
+
+# check that we are in the expected directory
+cd `dirname $0`/..
+
+./manage.py createsuperuser --noinput


### PR DESCRIPTION
This adds a script that creates a superuser, using details from the `DJANGO_SUPERUSER_*` environment variables (defaults to the values in docker-compose.yml).

@struan not sure whether we want to put this into `script/update`, or whether to leave it as a manual step? I figure _anyone_ running this code locally will want to set up a superuser… but really we’d only want it to be run when the database is _first_ set up (the user might delete the default superuser account, and not want it auto-recreated by `script/update`).