### PR TITLE
Vscode config setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+
+{
+	"name": "local-intelligence-hub",
+
+	"dockerComposeFile": ["../docker-compose.yml"],
+	"service": "web",
+	"workspaceFolder": "/app",
+	"overrideCommand": true,
+
+	"extensions": [
+		"ms-vscode.test-adapter-converter",
+		"bungcip.better-toml",
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"batisteo.vscode-django",
+		"ms-azuretools.vscode-docker",
+		"github.vscode-pull-request-github",
+		"mhutchie.git-graph"
+	]
+}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,32 @@
+# If linting checks pass ok, push to the git.mysociety.org mirror
+# Note: the git.mysociety.org repo pushes to this repo, and has priority. 
+# Force pushes will need to be made through other means.
+
+name: Mirror to git.mysociety.org
+
+on:
+  push:
+
+jobs:
+
+  lint:
+    uses: ./.github/workflows/lint.yml
+
+  mirror:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+        
+    - name: Push branch to git.mysociety.org
+      id: push_to_mirror
+      uses: mysociety/action-git-pusher@v1.1.0
+      with:
+        git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
+        ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}
+        tag: ${{ github.ref_name }} 
+        remote: 'ssh://gh-public@git.mysociety.org/data/git/public/local-intelligence-hub.git'

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [     
+        {
+            "name": "Run debug server",
+            "type": "python",
+            "request": "launch",
+            "justMyCode": false,
+            "program": "${workspaceFolder}/manage.py",
+            "args": [
+                "runserver"
+            ],
+            "django": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
+
+    "editor.formatOnSave": false,
+    "[python]": {
+        "editor.formatOnSave": true
+    },
+
+    "python.formatting.provider": "black",
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/*.pyc": {"when": "$(basename).py"}, 
+        "**/__pycache__": true
+    },
+    "files.associations": {
+        "**/*.html": "html",
+        "**/templates/**/*.html": "django-html",
+        "**/templates/**/*": "django-txt",
+        "**/requirements{/**,*}.{txt,in}": "pip-requirements"
+    },
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Path": "flake8",
+    "python.linting.enabled": true
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
 FROM python:3.9
-ENV PYTHONUNBUFFERED=1 \
+ENV INSIDE_DOCKER=1 \
+    PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
-    POETRY_VERSION=1.1.6 \
-    POETRY_VIRTUALENVS_IN_PROJECT=true \
-    POETRY_NO_INTERACTION=1 \
-    PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv"
-ENV PATH="$VENV_PATH/bin:$PATH"
+    POETRY_VERSION=1.2.2 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    PYSETUP_PATH="/opt/pysetup"
 RUN apt-get update && apt-get install -y \
     binutils gdal-bin libproj-dev git \
     && rm -rf /var/lib/apt/lists/*
-RUN pip install poetry==$POETRY_VERSION
+RUN curl -sSL https://install.python-poetry.org | python -
+ENV PATH="/root/.local/bin:$PATH"
 WORKDIR $PYSETUP_PATH
 COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-root
-WORKDIR /app
-COPY . .
+# Not needed (mapping handled by docker-compose)
+# WORKDIR /app
+# COPY . .
 #RUN ./manage.py collectstatic --no-input

--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ Start the Docker environment:
 
 (If Python complains about missing libraries, chances are the Python requirements have changed since your Docker image was last built. You can rebuild it with, eg: `docker-compose build web`.)
 
+Alternatively, for VScode users:
+
+1. Install the Remote-Container extension.
+2. In VScode Command pallette run `Remote-Containers: Install devcontainer CLI`
+3. Then in the repo dir, run `devcontainer open`.
+
+This will setup the docker containers and provide a BASH prompt into the containers. 
+
+The same config files means this repo also works in codespaces.
+
+You'll then need to run:
+
+`script/dev-populate`
+
+and then
+
+`script/server`
+
+For the dev server. 
+
+
 ### Data import
 
 You will then need to update the data by running the following

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       DJANGO_SUPERUSER_USERNAME: 'admin'
       DJANGO_SUPERUSER_PASSWORD: 'password'
       DJANGO_SUPERUSER_EMAIL: 'admin@localhost'
+    working_dir: /app
   mailhog:
     image: mailhog/mailhog:v1.0.1
     restart: always

--- a/local_intelligence_hub/settings.py
+++ b/local_intelligence_hub/settings.py
@@ -186,6 +186,7 @@ BOOTSTRAP5 = {
 if DEBUG and HIDE_DEBUG_TOOLBAR is False:  # pragma: no cover
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS = [ip[:-1] + "1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
+    CSRF_TRUSTED_ORIGINS = ["https://*.preview.app.github.dev"]
 
     # debug toolbar has to come after django_hosts middleware
     MIDDLEWARE.insert(1, "debug_toolbar.middleware.DebugToolbarMiddleware")

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,6 +9,15 @@ cd `dirname $0`/..
 if [ ! -f .env ] ; then
     echo "==> Seeding an initial .env from .env-example..."
     cp .env-example .env
+
+    # if INSIDE_DOCKER is set, write NATIVE to DEVENV in .env
+    if [ -n "$INSIDE_DOCKER" ] ; then
+        # delete line containing DEVENV from .env
+        sed -i '/DEVENV/d' .env
+        echo "==> Writing DEVENV=native to .env..."
+        echo 'DEVENV="native"' >> .env
+    fi
+
 fi
 
 if ! grep ^DEVENV .env ; then

--- a/script/dev-populate
+++ b/script/dev-populate
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+script/setup
+./manage.py import_areas
+./manage.py import_mps
+script/createsuperuser


### PR DESCRIPTION
This PR fixes some issues with developing *inside* the container (e.g. the vscode approach where it gives you a bash console inside the container, and so all management commands need to work in there).

The key change that may (but shouldn't) affect other aspects is the changes to the Dockerfile. Here I've turned off using virtualenvs inside the docker container (as it's the only thing in there), and this means that running `poetry add [x]` works fine while inside the container. Also involved using the new setup script for poetry and version 1.2.

`script/bootstrap` will now detect it is working inside the docker and change its default to (confusingly) 'native' (because it then is working 'natively' inside the docker when it calls other commands). 

It also adds a github action to mirror back to git.mysociety.org so commits can be made from codespaces straight to github and be available for review. 

End result works fine in codespaces, populates all data successfully. 