### PR TITLE
add a 404 page with lih branding

### DIFF
--- a/hub/tests/test_views.py
+++ b/hub/tests/test_views.py
@@ -5,6 +5,21 @@ from django.test import TestCase
 from django.urls import reverse
 
 
+class Test404Page(TestCase):
+    def testRequireLoginOver404(self):
+        url = "/page_does_not_exist"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test404page(self):
+        u = User.objects.create(username="user@example.com")
+        self.client.force_login(u)
+        url = "/page_does_not_exist"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertTemplateUsed(response, "404.html")
+
+
 class TestLoginEnforced(TestCase):
     def test_login_required(self):
         url = reverse("home")

--- a/hub/views.py
+++ b/hub/views.py
@@ -23,6 +23,22 @@ cache_settings = {
 }
 
 
+class NotFoundPageView(TitleMixin, TemplateView):
+    page_title = "Page not found"
+    template_name = "404.html"
+
+    def render_to_response(self, context, **response_kwargs):
+        response_kwargs.setdefault("content_type", self.content_type)
+        return self.response_class(
+            request=self.request,
+            template=self.get_template_names(),
+            context=context,
+            using=self.template_engine,
+            status=404,
+            **response_kwargs,
+        )
+
+
 class HomePageView(TitleMixin, TemplateView):
     page_title = ""
     template_name = "hub/home.html"

--- a/local_intelligence_hub/urls.py
+++ b/local_intelligence_hub/urls.py
@@ -20,6 +20,8 @@ from django.urls import include, path
 
 from hub import views
 
+handler404 = views.NotFoundPageView.as_view()
+
 urlpatterns = [
     path("", views.HomePageView.as_view(), name="home"),
     path("explore/", views.ExploreView.as_view(), name="explore"),

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,31 @@
+{% extends "hub/base.html" %}
+
+{% load django_bootstrap5 %}
+
+{% block content %}
+
+<div class="py-5">
+    <div class="container">
+        <h1 class="mb-4 text-primary">Page not found</h1>
+
+        <p>
+            {{ request.build_absolute_uri }} could not be found.
+        </p>
+
+        <h2 class="mt-5 mb-3 text-primary">Looking for local data?</h2>
+        <label class="form-label" for="search">Search by constituency name, MP name, or postcode</label>
+        <form class="row mt-2 mb-2" style="max-width: 30rem;" action="{% url 'area_search' %}">
+            <div class="col">
+                <div class="search-input search-input-lg">
+                    {% include 'hub/includes/icons/search.html' %}
+                    <input name="search" type="search" id="search" class="form-control form-control-lg">
+                </div>
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary btn-lg">Search</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Also has a search box to try and be helpful

To test this you need to go into `settings.py` and set `DEBUG = False`. You might also need to comment out 

```
if not DEBUG:  # pragma: no cover
    STATICFILES_STORAGE = (
        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
    )
```

As that might cause a 500 error when running with the local dev server.