### PR TITLE
MP appg import

### DIFF
--- a/hub/management/commands/import_mps_appg_data.py
+++ b/hub/management/commands/import_mps_appg_data.py
@@ -1,0 +1,111 @@
+from django.core.management.base import BaseCommand
+
+from mysoc_dataset import get_dataset_df, get_dataset_url
+from tqdm import tqdm
+
+from hub.models import DataSet, DataType, Person, PersonData
+
+party_lookup = {
+    "Conservative": "Conservative Party",
+    "Labour": "Labour Party",
+    "Liberal Democrat": "Liberal Democrats",
+    "Labour (Co-op)": "Labour Co-operative",
+    "Independent": "independent politician",
+    "Alliance": "Alliance Party of Northern Ireland",
+    "Green Party": "Green Party of England and Wales",
+    "Speaker": "Speaker of the House of Commons",
+    "Social Democratic & Labour Party": "Social Democratic and Labour Party",
+}
+
+
+class Command(BaseCommand):
+    help = "Import data on what APPGs an MP is part of"
+
+    source_url = "https://www.parliament.uk/mps-lords-and-offices/standards-and-financial-interests/parliamentary-commissioner-for-standards/registers-of-interests/register-of-all-party-party-parliamentary-groups/"
+    data_url = get_dataset_url(
+        repo_name="mp-appg-membership-data",
+        package_name="mp_appg_membership_data",
+        version_name="latest",
+        file_name="appg_officers.csv",
+    )
+
+    def handle(self, quiet=False, *args, **options):
+        self._quiet = quiet
+        self.import_results()
+
+    def add_mps(self, df):
+        # Adds the MPs as Person objects to the df - note that this sill not add all
+        # of the officers in the df, because some of them are in the house of Lords,
+        # rather than are MPs.
+        twfy_ids = PersonData.objects.filter(data_type__data_set__name="twfyid")
+        df.twfy_id = df.twfy_id.str[25:].astype(int)
+        df["mp"] = df.twfy_id.dropna().apply(
+            lambda x: twfy_ids.filter(data=x).first().person
+            if twfy_ids.filter(data=x)
+            else None
+        )
+        df = df.dropna(subset="mp")
+        return df
+
+    def get_df(self):
+        df = get_dataset_df(
+            repo_name="mp-appg-membership-data",
+            package_name="mp_appg_membership_data",
+            version_name="latest",
+            file_name="appg_officers.csv",
+        )
+        # Limit the df to only the APPGs relating to climate
+        # (Currently, this is done by reading from a list produced
+        # by searching for various keywords related to climate in the
+        # title and purposes of the APPGs)
+        with open("data/climate_APPGs.txt", "r") as fh:
+            climate_appgs = [line.replace("\n", "") for line in fh.readlines()]
+        df = df[df.appg_name.isin(climate_appgs)]
+        df = self.add_mps(df)
+        return df
+
+    def create_data_type(self):
+        appg_membership_ds, created = DataSet.objects.update_or_create(
+            name="mp_appg_memberships",
+            defaults={
+                "data_type": "text",
+                "description": "Membership in APPGs as published on the parliament website",
+                "label": "APPG Memberships",
+                "source_label": "UK Parliament",
+                "source": "https://parliament.uk/",
+                "table": "person__persondata",
+            },
+        )
+
+        appg_membership, created = DataType.objects.update_or_create(
+            data_set=appg_membership_ds,
+            name="mp_appg_memberships",
+            defaults={"data_type": "text"},
+        )
+
+        return appg_membership
+
+    def get_results(self):
+        mps = Person.objects.filter(person_type="MP")
+        df = self.get_df()
+        results = {}
+        for mp in mps.all():
+            mp_df = df[df.mp == mp]
+            if len(mp_df) != 0:
+                results[mp] = list(mp_df.appg_name)
+        return results
+
+    def add_results(self, results, data_type):
+        print("Adding APPG data to Django database")
+        for mp, result_list in tqdm(results.items(), disable=self._quiet):
+            for result in result_list:
+                data, created = PersonData.objects.update_or_create(
+                    person=mp,
+                    data_type=data_type,
+                    data=result,
+                )
+
+    def import_results(self):
+        data_type = self.create_data_type()
+        results = self.get_results()
+        self.add_results(results, data_type)

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -58,6 +58,12 @@
                           {% if mp.party %}
                             <li class="mb-2"><a href="#">{{ mp.party }}</a></li>
                           {% endif %}
+                          {% if mp.appg_memberships %}
+                              <li class="mb-2 fw-bold">APPGs:</li>
+                              {% for appg in mp.appg_memberships %}
+                              <li class="mb-2">{{ appg }}</li>
+                              {% endfor %}
+                          {% endif %}
                         </ul>
                     </div>
                     <div class="card-footer bg-white">
@@ -159,5 +165,4 @@
 
     </div>
 </div>
-
 {% endblock %}

--- a/hub/views.py
+++ b/hub/views.py
@@ -258,6 +258,9 @@ class AreaView(BaseAreaView):
             ).select_related("data_type")
             for item in data.all():
                 context["mp"][item.data_type.name] = item.value()
+            context["mp"]["appg_memberships"] = [
+                item.value() for item in data.filter(data_type__name="appg_membership")
+            ]
         except Person.DoesNotExist:
             pass
 


### PR DESCRIPTION
APPG data import, fixes #37 

Relies on a list of climate APPGs which can be accessed by saving [this Google doc](https://docs.google.com/document/d/1AF5eyeHJSGqOALHMSrHDZjSHBvRN--Wm451_iYia7kw/edit?usp=sharing) as a text file. 
(This document was created by manually grepping the APPG names and descriptions for climate-related words. It may be a bit overzealous.)

Similar to the Select Committee memberships, it has a slightly janky method of displaying the APPGs in a view.

The APPGs are displayed in long lists, which doesn't look good with the rest of the layout.