### PR TITLE
“Public” list of all dataset names and sources

### DIFF
--- a/hub/templates/hub/includes/footer.html
+++ b/hub/templates/hub/includes/footer.html
@@ -8,7 +8,7 @@
             <div class="col-md-6 col-lg-5 offset-lg-1 mb-4">
                 <ul class="nav site-footer__nav">
                     <li class="nav-item w-50">
-                        <a class="nav-link" href="#">Data sources</a>
+                        <a class="nav-link" href="{% url 'sources' %}">Data sources</a>
                     </li>
                     <li class="nav-item w-50">
                         <a class="nav-link" href="#">Privacy Policy</a>

--- a/hub/templates/hub/sources.html
+++ b/hub/templates/hub/sources.html
@@ -1,0 +1,31 @@
+{% extends "hub/base.html" %}
+
+{% block content %}
+
+<div class="py-4 py-lg-5">
+    <div class="container">
+
+        <h1>Datasets and data sources</h1>
+
+        <table class="table mt-4">
+            <thead>
+                <tr>
+                    <th class="ps-0 d-none d-sm-table-cell" scope="col">Category</th>
+                    <th class="ps-0 px-sm-3 px-md-4" scope="col">Dataset</th>
+                    <th class="pe-0" scope="col">Source</th>
+                </tr>
+            </thead>
+            <tbody>
+              {% for dataset in datasets %}
+                <tr>
+                    <td class="ps-0 d-none d-sm-table-cell">{{ dataset.category|default_if_none:''|title }}</td>
+                    <td class="ps-0 px-sm-3 px-md-4">{{ dataset.label }}</td>
+                    <td class="pe-0"><a href="{{ dataset.source }}">{{ dataset.source_label }}</a></td>
+                </tr>
+              {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{% endblock %}

--- a/hub/views.py
+++ b/hub/views.py
@@ -51,6 +51,16 @@ class ExploreView(TitleMixin, TemplateView):
     template_name = "hub/explore.html"
 
 
+class SourcesView(TitleMixin, TemplateView):
+    page_title = "Datasets and data sources"
+    template_name = "hub/sources.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["datasets"] = DataSet.objects.all().order_by("category", "label")
+        return context
+
+
 class ExploreDatasetsJSON(TemplateView):
     def render_to_response(self, context, **response_kwargs):
         datasets = []

--- a/local_intelligence_hub/urls.py
+++ b/local_intelligence_hub/urls.py
@@ -48,6 +48,7 @@ urlpatterns = [
         views.UnFavouriteDataSetView.as_view(),
         name="unfavourite_dataset",
     ),
+    path("sources/", views.SourcesView.as_view(), name="sources"),
     path("location/", views.AreaSearchView.as_view(), name="area_search"),
     path("style/", views.StyleView.as_view(), name="style"),
     path("status/", views.StatusView.as_view(), name="status"),


### PR DESCRIPTION
![Screenshot 2022-12-12 at 13-56-09 Datasets and data sources Local Intelligence Hub](https://user-images.githubusercontent.com/739624/207063680-ccc2d743-bc59-4acd-939f-d82fd3e78b13.png)

This information is already sort of available through the Explore page filter/shader picker, but putting it on its own page is much easier to share, to give people an overview of what’s in the platform and where it’s come from.