### PR TITLE
FoE groups data import

### DIFF
--- a/hub/management/commands/import_foe_groups.py
+++ b/hub/management/commands/import_foe_groups.py
@@ -1,0 +1,52 @@
+from django.conf import settings
+
+import pandas as pd
+
+from hub.models import AreaData, DataSet
+
+from .base_importers import BaseImportFromDataFrameCommand
+
+
+class Command(BaseImportFromDataFrameCommand):
+    help = "Import data about number of FOE groups per constituency"
+
+    data_file = settings.BASE_DIR / "data" / "foe_groups.csv"
+    cons_row = "constituency"
+    message = "Importing FOE groups data"
+    uses_gss = False
+
+    defaults = {
+        "data_type": "integer",
+        "category": "movement",
+        "source_label": "Friends of the Earth",
+        "source": "https://friendsoftheearth.uk/",
+        "source_type": "google sheet",
+        "table": "areadata",
+        "default_value": 10,
+        "data_url": "",
+        "comparators": DataSet.numerical_comparators(),
+    }
+
+    data_sets = {
+        "constituency_foe_groups_count": {
+            "defaults": defaults,
+            "col": "groups",
+        },
+    }
+
+    def get_dataframe(self):
+        df = pd.read_csv(
+            self.data_file,
+            usecols=["Westminster constituency", "Groups located within constituency"],
+        )
+        df = df.dropna()
+        df = df.groupby("Westminster constituency").size().reset_index()
+        df.columns = ["constituency", "groups"]
+        df.groups = df.groups.astype(int)
+        return df
+
+    def get_label(self, defaults):
+        return "Number of active Friends of the Earth groups"
+
+    def delete_data(self):
+        AreaData.objects.filter(data_type__in=self.data_types.values()).delete()


### PR DESCRIPTION
Fixes #65 

Simple data import for FoE groups data.

Uses first sheet, named `foe_groups.csv` but otherwise unaltered from relevant Sheets document in shared drive.