### PR TITLE
Select Committee Membership

### DIFF
--- a/hub/management/commands/import_mps_select_committee_membership.py
+++ b/hub/management/commands/import_mps_select_committee_membership.py
@@ -1,0 +1,84 @@
+from django.core.management.base import BaseCommand
+
+import pandas as pd
+import requests
+from tqdm import tqdm
+
+from hub.models import DataSet, DataType, Person, PersonData
+
+COMMITTEE_REQUEST_URL = "https://committees-api.parliament.uk/api/Committees"
+
+
+class Command(BaseCommand):
+    help = "Import select committee memberships for UK Members of Parliament"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-q", "--quiet", action="store_true", help="Silence progress bars."
+        )
+
+    def handle(self, quiet=False, *args, **options):
+        self._quiet = quiet
+        self.import_results()
+
+    def get_results(self):
+        if not self._quiet:
+            self.stdout.write("Fetching all current Select Committee memberships")
+
+        mps = Person.objects.filter(person_type="MP")
+        mp_ids = list(mps.values_list("external_id", flat=True))
+
+        select_committees_json = []
+        for mp in tqdm(mp_ids, disable=self._quiet):
+            response = requests.get(
+                f"https://committees-api.parliament.uk/api/Members?Members={str(mp)}&MembershipStatus=Current&CommitteeCategory=Select"
+            )
+            if response.status_code == 200:
+                response_json = response.json()
+                if response_json != []:
+                    select_committees_json.extend(response_json)
+            else:
+                self.stdout.write(f"Request failed for MP with ID: {str(mp)}")
+
+        df = pd.DataFrame.from_records(select_committees_json)[["committees", "id"]]
+        df = df.explode("committees")
+        df["committee_name"] = df.committees.str["name"]
+        df["mp"] = df.id.apply(lambda mp_id: mps.get(external_id=mp_id))
+        return df
+
+    def create_data_types(self):
+        if not self._quiet:
+            self.stdout.write("Creating data set and type")
+        select_committee_membership_ds, created = DataSet.objects.update_or_create(
+            name="select_committee_membership",
+            defaults={
+                "data_type": "text",
+                "description": "MP Membership in Select Committees",
+                "label": "Membership in Select Committees",
+                "source_label": "UK Parliament",
+                "source": "https://parliament.uk/",
+                "table": "person__persondata",
+            },
+        )
+        select_committee_membership, created = DataType.objects.update_or_create(
+            data_set=select_committee_membership_ds,
+            name="select_committee_membership",
+            defaults={"data_type": "text"},
+        )
+
+        return select_committee_membership
+
+    def add_results(self, results, data_type):
+        if not self._quiet:
+            self.stdout.write("Adding Select Committee Membership")
+        for index, result in tqdm(results.iterrows(), disable=self._quiet):
+            committee_membership, created = PersonData.objects.update_or_create(
+                person=result.mp,
+                data_type=data_type,
+                defaults={"data": result.committee_name},
+            )
+
+    def import_results(self):
+        data_type = self.create_data_types()
+        results = self.get_results()
+        self.add_results(results, data_type)

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -58,6 +58,14 @@
                           {% if mp.party %}
                             <li class="mb-2"><a href="#">{{ mp.party }}</a></li>
                           {% endif %}
+                          {% if mp.select_committee_memberships %}
+                            <li class="mb-2 fw-bold">Select Committees:</li>
+                            <ul class="list-unstyled mb-0">
+                            {% for committee in mp.select_committee_memberships %}
+                              <li class="mb-2">{{ committee }}</li>
+                            {% endfor %}
+                            </ul>
+                          {% endif %}
                           {% if mp.appg_memberships %}
                               <li class="mb-2 fw-bold">APPGs:</li>
                               {% for appg in mp.appg_memberships %}

--- a/hub/views.py
+++ b/hub/views.py
@@ -257,7 +257,20 @@ class AreaView(BaseAreaView):
                 person=context["mp"]["person"]
             ).select_related("data_type")
             for item in data.all():
-                context["mp"][item.data_type.name] = item.value()
+                if (
+                    item.data_type.name == "select_committee_membership"
+                    and "select_committee_memberships" not in context["mp"]
+                ):
+                    context["mp"]["select_committee_memberships"] = [
+                        datum["data"]
+                        for datum in PersonData.objects.filter(
+                            person=context["mp"]["person"]
+                        )
+                        .filter(data_type__name="select_committee_membership")
+                        .values()
+                    ]
+                else:
+                    context["mp"][item.data_type.name] = item.value()
             context["mp"]["appg_memberships"] = [
                 item.value() for item in data.filter(data_type__name="appg_membership")
             ]


### PR DESCRIPTION
Fixes #36 
Script uses the Parliament Committees API to pull down the MP memberships.
The API appears to allow multiple MPs to be searched in one request, but I couldn't get this to function properly, so it makes a call for each MP individually at the moment - this doesn't seem ideal, but hasn't caused any issues when I've ran it other than taking a bit of a while.

The way this is shown in the view seems a little janky. Is there a better way of implementing it as-is, or should I be configuring the data models differently? Is it worth adding a 'list'(like) datatype?