### PR TITLE
MP Job titles

### DIFF
--- a/hub/management/commands/import_mp_job_titles.py
+++ b/hub/management/commands/import_mp_job_titles.py
@@ -1,0 +1,86 @@
+from django.core.management.base import BaseCommand
+
+import pandas as pd
+from tqdm import tqdm
+
+from hub.models import Area, DataSet, DataType, Person, PersonData
+
+CONSTITUENCY_CORRECTIONS_DICT = {
+    "Beverly and Holderness": "Beverley and Holderness",
+    "Brighton Pavilion": "Brighton, Pavilion",
+    "Enfield Southgate": "Enfield, Southgate",
+    "Lewisham Deptford": "Lewisham, Deptford",
+    "Ealing Southall": "Ealing, Southall",
+    "Brighton Kemptown": "Brighton, Kemptown",
+    "Richmond": "Richmond (Yorks)",
+    "Na h-Eileanan an Lar": "Na h-Eileanan an Iar",
+}
+
+
+class Command(BaseCommand):
+    help = "Import MP Job titles"
+
+    def handle(self, quiet=False, *args, **options):
+        self._quiet = quiet
+        self.import_results()
+
+    def get_df(self):
+        df = pd.read_csv("data/mp_job_titles.csv", usecols=["Constituency", "Title"])
+        df = df.query(
+            "not(Title.str.contains('^ ?(((MP)|(Member of Parliament)) for .*)|(Member of .*Select Committee)$'))"
+        ).copy()
+
+        # Clean the constituency data:
+        df.Constituency = df.Constituency.str.strip()
+        df.Constituency = df.Constituency.apply(
+            lambda x: CONSTITUENCY_CORRECTIONS_DICT.get(x, x)
+        )
+        return df
+
+    def create_data_type(self):
+        mp_job_titles_ds, created = DataSet.objects.update_or_create(
+            name="job_titles",
+            defaults={
+                "data_type": "text",
+                "description": "MP job titles (on top of being Members of Parliament)",
+                "label": "MP Job Titles",
+                "source_label": "Green Alliance",
+                "source": "https://green-alliance.org.uk/",
+                "table": "person__persondata",
+            },
+        )
+
+        mp_job_titles, created = DataType.objects.update_or_create(
+            data_set=mp_job_titles_ds,
+            name="job_titles",
+            defaults={"data_type": "text"},
+        )
+
+        return mp_job_titles
+
+    def get_results(self):
+        mps = Person.objects.filter(person_type="MP")
+        df = self.get_df()
+        results = {}
+        print("Matching MPs with titles")
+        for index, row in df.iterrows():
+            try:
+                area = Area.objects.get(name__iexact=row.Constituency)
+                results[mps.get(area=area)] = row.Title
+            except Area.DoesNotExist:
+                print(f"Constituency: {row.Constituency} not found.")
+        return results
+
+    def add_results(self, results, data_type):
+        print("Adding MP job title data to Django database")
+        for mp, job_title in tqdm(results.items(), disable=self._quiet):
+            data, created = PersonData.objects.update_or_create(
+                person=mp,
+                data_type=data_type,
+                data=job_title,
+            )
+
+    def import_results(self):
+        data_type = self.create_data_type()
+        results = self.get_results()
+        self.add_results(results, data_type)

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -43,10 +43,16 @@
                                 <h4 class="h6 mt-4">2019 majority</h4>
                                 <p class="fs-5 lh-1 fw-bold text-primary mb-0">{{ mp.mp_election_majority|intcomma }}</p>
                             </div>
+                          {% if mp.job_titles %}
+                            <div>
+                                <h4 class="h6 mt-4 mb-1">Positions</h4>
+                                <p class="mb-0">{{ mp.job_titles }}</p>
+                            </div>
+                          {% endif %}
                         </div>
                     </div>
                     <div class="card-footer bg-white">
-                        <p class="card-text fs-8 text-muted">Data from <a href="https://www.theyworkforyou.com/{% if mp.twfyid %}mp/{{ mp.twfyid}}{% endif %}" class="text-decoration-none text-muted">TheyWorkForYou.com</a> and <a href="https://electionresults.parliament.uk/election/2019-12-12/Statistics/Majority" class="text-decoration-none text-muted">UK Parliament</a></p>
+                        <p class="card-text fs-8 text-muted">Data from <a href="https://www.theyworkforyou.com/{% if mp.twfyid %}mp/{{ mp.twfyid}}{% endif %}" class="text-decoration-none text-muted">TheyWorkForYou.com</a>{% if mp.job_titles %},{% else %} and{% endif %} <a href="https://electionresults.parliament.uk/election/2019-12-12/Statistics/Majority" class="text-decoration-none text-muted">UK Parliament</a>{% if mp.job_titles %}, and Green Alliance{% endif %}</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #84 

Just drags them in verbatim, rather than trying to process the textual data.

Currently, it fixes errors in Constituency names manually (as there weren't many), but possibly this could be fixed in the csv itself, as the changes are hard-coded anyway.