### PR TITLE
Show data_type hints (eg: "%") in Explore page filters

### DIFF
--- a/hub/templates/hub/explore.html
+++ b/hub/templates/hub/explore.html
@@ -31,6 +31,11 @@
                     <select v-if="filter.options" v-model="filter.selectedValue" class="form-select form-select-sm ms-3 flex-grow-1 flex-shrink-1">
                         <option v-for="option in filter.options" :value="option">${ option }</option>
                     </select>
+                    <div v-else-if="filter.data_type == 'percent'" class="input-group ms-3 flex-grow-1 flex-shrink-1">
+                        <input type="text" inputmode="numeric" pattern="[0-9]*" v-model="filter.selectedValue" class="form-control form-control-sm text-end">
+                        <span class="input-group-text lh-1">%</span>
+                    </div>
+                    <input v-else-if="filter.data_type == 'integer'" type="text" inputmode="numeric" pattern="[0-9]*" v-model="filter.selectedValue" class="form-control form-control-sm ms-3 flex-grow-1 flex-shrink-1">
                     <input v-else type="text" v-model="filter.selectedValue" class="form-control form-control-sm ms-3 flex-grow-1 flex-shrink-1">
                 </div>
             </div>

--- a/hub/views.py
+++ b/hub/views.py
@@ -102,6 +102,7 @@ class ExploreDatasetsJSON(TemplateView):
                 options=options if len(options) > 0 else None,
                 defaultValue=d.default_value,
                 is_range=d.is_range,
+                data_type=d.data_type,
             )
             if d.is_range:
                 ds["types"] = [


### PR DESCRIPTION
When adding a new filter on the Explore page, the value input will be followed by a "%" if the value must be a percentage, and will trigger a numeric keypad on touchscreen devices if the value must be numeric.

Fixes #92.

Here it is in action, on two percentage datasets, and two integer datasets:

<img width="484" alt="Screenshot 2023-02-02 at 16 13 12" src="https://user-images.githubusercontent.com/739624/216380668-ea6f2e57-fda8-4e2c-b4a0-8a0fcc5ea3b1.png">
