### PR TITLE
Replace hard-coded /status with a proper health check

### DIFF
--- a/hub/templates/hub/status.html
+++ b/hub/templates/hub/status.html
@@ -1,1 +1,0 @@
-status: OK

--- a/hub/tests/test_views.py
+++ b/hub/tests/test_views.py
@@ -357,4 +357,6 @@ class TestStatusView(TestCase):
         url = reverse("status")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertRegex(response.content, rb"status: OK")
+        self.assertEqual(response.json()["database"], "ok")
+        self.assertEqual(response.json()["areas"], 0)
+        self.assertEqual(response.json()["datasets"], 0)


### PR DESCRIPTION
Saw this hanging out at the bottom of the issue list and thought, bah, how hard can it be.

Nice new `/status` endpoint that returns JSON, with a 500 HTTP status code if there was an issue connecting to the database:

```json
{"database": "ok", "areas": 650, "datasets": 35}
```

Turns out it’s slightly messy checking for a database connection in Django. Got it down to 7 or 8 lines. Still, probably simpler than adding a dependency like [django-health-check](https://pypi.org/project/django-health-check/) which would do _way_ more than we need.

Fixes #24.