### PR TITLE
Script for Python linting inside or outside Docker container

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,13 @@
 
     "editor.formatOnSave": false,
     "[python]": {
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        }
     },
-
     "python.formatting.provider": "black",
+    "python.formatting.blackPath": "${workspaceFolder}/script/black",
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,
@@ -23,6 +26,9 @@
         "**/requirements{/**,*}.{txt,in}": "pip-requirements"
     },
     "python.linting.flake8Enabled": true,
-    "python.linting.flake8Path": "flake8",
+    "python.linting.flake8Path": "${workspaceFolder}/script/flake8",
+    "python.linting.flake8Args": [
+        "--exclude \".venv\" ."
+    ],
     "python.linting.enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 A Beta verion of a tool to help The Climate Coalition with better access
 to data needed to enable local and national action on climate.
 
-# Contract Countdown
-
-
 The [original static prototype](https://github.com/mysociety/local-intelligence-hub/commit/4fab6ff08401d4e4c29615ab07ff4f6c4f4e6050) was built as part of mySociety’s August 2022 prototyping week exploring how The Climate Coalition might we give climate campaign organisations and communities better access to the data they need to enable local and national action on climate.
 
 ## Development install
@@ -18,7 +15,7 @@ Clone the repository:
     cd local-intellegence-hub
 
 Create and edit a .env file using `.env-example` file and then
-update `SECRET_KEY` and `MAPIT_API_KEY`. You can get the latter from (https://mapit.mysociety.org/account/signup/)
+update `SECRET_KEY` and `MAPIT_API_KEY`. You can get the latter from https://mapit.mysociety.org/account/signup/
 
 Start the Docker environment:
 
@@ -38,28 +35,26 @@ The same config files means this repo also works in codespaces.
 
 You'll then need to run:
 
-`script/dev-populate`
+    script/dev-populate
 
-and then
+and then:
 
-`script/server`
+    script/server
 
 For the dev server. 
 
 
 ### Data import
 
-You will then need to update the data by running the following
-management commands in the docker web container:
+You will then need to update the data by running at least the following management commands either inside or outside the container:
 
-* `./manage.py import_areas` - this will take some time to run
-* `./manage.py import_mps`
+* `script/manage import_areas` - this will take some time to run
+* `script/manage import_mps`
 
 You can then view it at (http://localhost:8000/)
 
-You can create the first Django user by entering a bash shell inside the `web` container, and then running the `createsuperuser` script through the Django shell:
+You can create the first Django user from inside or outside the container with:
 
-    docker-compose exec web bash
     script/createsuperuser
 
 The superuser will be created with the details specified in the `DJANGO_SUPERUSER_*` environment variables. [Read more about how Docker handles environment variables](https://docs.docker.com/compose/envvars-precedence/).
@@ -70,9 +65,14 @@ First start the Docker environment:
 
     docker-compose up
 
-Then enter a bash shell inside the `web` container, and run the tests from there:
+Then run the tests from inside or outside the docker container:
 
-    docker-compose exec web bash
     script/test
 
 The first time you run `script/test`, it will ask whether you want the tests to run natively or inside the docker container. Type `docker` to run them inside the docker container. Your preference will be saved to `.env` for future runs.
+
+### Linting and formatting code
+
+You can run the linting and formatting suite from inside or outside the docker container:
+
+    script/lint

--- a/hub/templates/hub/status.html
+++ b/hub/templates/hub/status.html
@@ -1,1 +1,0 @@
-status: OK

--- a/hub/tests/test_views.py
+++ b/hub/tests/test_views.py
@@ -357,4 +357,6 @@ class TestStatusView(TestCase):
         url = reverse("status")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertRegex(response.content, rb"status: OK")
+        self.assertEqual(response.json()["database"], "ok")
+        self.assertEqual(response.json()["areas"], 0)
+        self.assertEqual(response.json()["datasets"], 0)

--- a/script/black
+++ b/script/black
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# dev environment independent way of referencing black in settings.json
+
+cd `dirname $0`/..
+
+script/dev-command black $@

--- a/script/createsuperuser
+++ b/script/createsuperuser
@@ -6,4 +6,4 @@ set -e
 # check that we are in the expected directory
 cd `dirname $0`/..
 
-./manage.py createsuperuser --noinput
+script/dev-command ./manage.py createsuperuser --noinput

--- a/script/dev-command
+++ b/script/dev-command
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Generic script to run a command in the current dev enviroment
+# e.g. `script/dev-command black .` will run black either natively,
+# in poetry, or in docker, depending on config
+
+# check that we are in the expected directory
+cd `dirname $0`/..
+
+source .env
+
+# if no extra arguments made to script, throw an error
+if [ $# -eq 0 ]; then
+    echo "No arguments provided to script/dev-command"
+    exit 1
+fi
+
+if [ "$INSIDE_DOCKER" == 1 ] ; then
+    # already inside container :-)
+    # run command directly, no need for virtualenv
+    PREFIX=""
+elif [ "$DEVENV" == "docker" ] ; then
+    # not inside container but should be :-(
+    # run the command inside the container
+    PREFIX="docker-compose exec web"
+else
+    # not inside container and don’t need to be :-)
+    # run command in virtualenv with poetry
+    PREFIX="poetry run"
+fi
+
+# use the prefix and the arguments passed to the script to run the command
+$PREFIX $@

--- a/script/flake8
+++ b/script/flake8
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# dev environment independent way of referencing flake8 in settings.json
+
+cd `dirname $0`/..
+
+script/dev-command flake8 $@

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# check that we are in the expected directory
+cd `dirname $0`/..
+
+source .env
+
+if [ "$INSIDE_DOCKER" == 1 ] ; then
+    # already inside container :-)
+    # run linting directly, no need for virtualenv
+    PREFIX=""
+elif [ "$DEVENV" == "docker" ] ; then
+    # not inside container but should be :-(
+    # run this script again _inside_ the container
+    docker-compose exec web script/lint
+    exit
+else
+    # not inside container and don’t need to be :-)
+    # run linting with `poetry run` (in a virtualenv)
+    PREFIX="poetry run"
+fi
+
+$PREFIX black .
+$PREFIX isort .
+$PREFIX flake8 --exclude ".venv" .

--- a/script/lint
+++ b/script/lint
@@ -1,25 +1,10 @@
 #!/bin/bash
 
+# Run all linting commands
+
 # check that we are in the expected directory
 cd `dirname $0`/..
 
-source .env
-
-if [ "$INSIDE_DOCKER" == 1 ] ; then
-    # already inside container :-)
-    # run linting directly, no need for virtualenv
-    PREFIX=""
-elif [ "$DEVENV" == "docker" ] ; then
-    # not inside container but should be :-(
-    # run this script again _inside_ the container
-    docker-compose exec web script/lint
-    exit
-else
-    # not inside container and don’t need to be :-)
-    # run linting with `poetry run` (in a virtualenv)
-    PREFIX="poetry run"
-fi
-
-$PREFIX black .
-$PREFIX isort .
-$PREFIX flake8 --exclude ".venv" .
+script/dev-command black .
+script/dev-command isort .
+script/dev-command flake8 --exclude ".venv" .

--- a/script/manage
+++ b/script/manage
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -f "$(dirname $0)"/../.venv/bin/activate ] && . "$(dirname $0)"/../.venv/bin/activate
+# check that we are in the expected directory
+cd `dirname $0`/..
 
-managepy="$(dirname "$0")/../manage.py"
-python3 "$managepy" "$@"
+script/dev-command ./manage.py "$@"

--- a/script/test
+++ b/script/test
@@ -8,15 +8,8 @@ cd `dirname $0`/..
 
 script/bootstrap
 
-source .env
-if [ "$DEVENV" == "docker" ] ; then
-    PREFIX=""
-else
-    PREFIX="poetry run"
-fi
-
 if [ "$1" == "--coverage" ]; then
-    $PREFIX coverage run --source=. --branch manage.py test
+    script/dev-command coverage run --source=. --branch manage.py test
 else
-    $PREFIX ./manage.py test
+    script/dev-command ./manage.py test
 fi


### PR DESCRIPTION
`script/lint` convenience wrapper for our three linting tools. (Because, despite `.vscode/settings.json`, I could never seem to make `flake8` etc available on VSCode’s path to get automated linting to work.)

If a Docker environment is present, it’ll run the linting inside that (respawning itself _inside_ the container if you run it from _outside_). Otherwise, it will assume you want to run natively, inside a Python `poetry` environment.

@ajparsons I’d love your thoughts on this. Not sure if/how it should work with `.vscode/settings.json`.