### PR TITLE
Groups UI change

### DIFF
--- a/hub/management/commands/generate_wi_groups_csv.py
+++ b/hub/management/commands/generate_wi_groups_csv.py
@@ -1,0 +1,128 @@
+import re
+from time import sleep
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+import pandas as pd
+import requests
+from tqdm import tqdm
+
+from hub.models import Area
+from utils.mapit import (
+    BadRequestException,
+    ForbiddenException,
+    InternalServerErrorException,
+    MapIt,
+    NotFoundException,
+    RateLimitException,
+)
+
+GROUPS_URL = "https://wi-search.squiz.cloud/s/search.json?collection=nfwi-federations&profile=_default&query=!null&sort=prox&sort=prox&start_rank=1&origin=54.093409,-2.89479&maxdist=9999&num_ranks=9999"
+
+
+class Command(BaseCommand):
+    help = "Generate CSV file of WI Groups'"
+    tqdm.pandas()
+
+    out_file = settings.BASE_DIR / "data" / "wi_groups.csv"
+
+    def get_dataframe(self):
+        if not self._quiet:
+            self.stdout.write("Downloading data from API")
+        results = requests.get(GROUPS_URL)
+        data = results.json()["response"]["resultPacket"]["results"]
+
+        df = pd.DataFrame.from_records(data)
+        df["lat_lon"] = df.metaData.str["x"]
+
+        df = df[["title", "liveUrl", "lat_lon"]]
+        df.columns = ["group_name", "url", "lat_lon"]
+        return df
+
+    def _process_lat_long(self, lat_lon=None, row_name=None):
+        try:
+            lat, lon = re.split(r"[,;]", lat_lon)
+        except ValueError:
+            print(f"bad lat_lon for row {row_name} - {lat_lon}")
+            return None
+        if not pd.isna(lat) and not pd.isna(lon):
+            try:
+                mapit = MapIt()
+                gss_codes = mapit.wgs84_point_to_gss_codes(lon, lat)
+
+                area = Area.objects.filter(gss__in=gss_codes).first()
+                if area:
+                    return area.name
+                else:
+                    return None
+            except (
+                NotFoundException,
+                BadRequestException,
+                InternalServerErrorException,
+                ForbiddenException,
+            ) as error:
+                print(f"Error fetching row {row_name} with {lat}, {lon}: {error}")
+                return None
+            except RateLimitException as error:
+                print(f"Mapit Error - {error}, waiting for a minute")
+                sleep(60)
+                return False
+        else:
+            print(f"missing lat or lon for row {row_name}")
+            return None
+
+    def process_lat_long(self, lat_lon=None, row_name=None):
+        success = self._process_lat_long(lat_lon=lat_lon, row_name=row_name)
+        # retry once if it fails so we can catch rate limit errors
+        if success is False:
+            return self._process_lat_long(lat_lon=lat_lon, row_name=row_name)
+        else:
+            return success
+
+    def process_data(self, df):
+        if not self._quiet:
+            self.stdout.write("Generating GSS codes from lat + lon values")
+        if not self._ignore:
+            # Download existing csv, if it exists, so that data isn't updated redundantly
+            try:
+                old_df = pd.read_csv(self.out_file, usecols=["lat_lon", "area"])
+                lat_long_lookup = {
+                    row.lat_lon: row.area for index, row in old_df.iterrows()
+                }
+                if not self._quiet:
+                    self.stdout.write("Reading codes from existing file")
+                df["area"] = df.apply(
+                    lambda row: lat_long_lookup.get((row.lat_lon), None), axis=1
+                )
+            except FileNotFoundError:
+                print("No existing file.")
+
+        if not self._quiet:
+            self.stdout.write("Generating GSS codes for new WI groups")
+
+        df["area"] = df.progress_apply(
+            lambda row: self.process_lat_long(row.lat_lon, row.group_name)
+            if pd.isna(row.area)
+            else row.area,
+            axis=1,
+        )
+        return df
+
+    def save_data(self, df):
+        df.to_csv(self.out_file, index=False)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-q", "--quiet", action="store_true", help="Silence progress bars."
+        )
+        parser.add_argument(
+            "-i", "--ignore", action="store_true", help="Ignore existing data file"
+        )
+
+    def handle(self, quiet=False, ignore=False, *args, **options):
+        self._quiet = quiet
+        self._ignore = ignore
+        df = self.get_dataframe()
+        out_df = self.process_data(df)
+        self.save_data(out_df)

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -275,26 +275,17 @@
                                     <h5>Groups</h5>
                                 </div>
                                 <div class="card-body">
-                                    <table class="table mb-0">
-                                        <thead>
-                                            <tr>
-                                                <th scope="col">Organisation</th>
-                                                <th scope="col">This area</th>
-                                                <th scope="col" class="text-muted">UK average</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
                                           {% for datum in categories.movement %}
                                             {% if datum.subcategory == "groups" %}
-                                            <tr>
-                                                <th>{{ datum.name | simplify_dataset_name }}</th>
-                                                <td>{{ datum.data.value|floatformat }}</td>
-                                                <td class="text-muted">{{ datum.data.average|floatformat }}</td>
-                                            </tr>
+                                                <h6 class="text-muted fw-bold">{{ datum.label }}</h6>
+                                                <ul class="tag-cloud">
+                                                {% for data in datum.data.json %}
+                                                    <li><a href="{{ data.url }}" class="tag" title="{{ datum.label }}">{{ data.group_name }}</a></li>
+                                                {% endfor %}
+                                                </ul>
                                             {% endif %}
                                           {% endfor %}
-                                        </tbody>
-                                    </table>
+
                                 </div>
                                 <div class="card-footer bg-white">
                                     <p class="card-text fs-8"><a href="{% url 'sources' %}" class="text-decoration-none text-muted">Data from members of The Climate Coalition</a></p>


### PR DESCRIPTION
This PR changes how groups are both imported and displayed, such that they will show the groups in a tag cloud with links to the group's URL where possible (instead of a count of those groups).

This consists of these changes:
- Splitting the WI import into a generation + import script
  - Also, changing which information is imported to grab a link and name
- Changing the FoE import script to import names of groups instead of counts
- Changing how this information is displayed in the UI 

To deploy this, the following additional steps will need to be ran:
- Removing the following datasets:
  - Number of Friends of the Earth groups
  - Number of Women's Institute groups
- Rerun the FoE groups import
- Rerun the Women's Institute import
  - (To do this, either the csv will need to be generated with the new command, or the csv can be copied across and just the import command ran, to save time) 