### PR TITLE
Improved naming and comparators for MP job titles dataset

### DIFF
--- a/hub/management/commands/import_mp_job_titles.py
+++ b/hub/management/commands/import_mp_job_titles.py
@@ -42,11 +42,12 @@ class Command(BaseCommand):
             name="job_titles",
             defaults={
                 "data_type": "text",
-                "description": "MP job titles (on top of being Members of Parliament)",
-                "label": "MP Job Titles",
+                "description": "Positions such as cabinet and shadow minister roles, spokespeople, and whips",
+                "label": "MP positions (job titles)",
                 "source_label": "Green Alliance",
                 "source": "https://green-alliance.org.uk/",
                 "table": "person__persondata",
+                "comparators": DataSet.string_comparators(),
             },
         )
 


### PR DESCRIPTION
Using string comparators (rather than default equality comparison) means you can search for all constituencies with an MP whose position contains "minister" or "shadow" or "whip" etc.

I’ve updated the name to include "positions", to match how it’s labelled on the area page.