### PR TITLE
192 dataset names and sources

### DIFF
--- a/hub/management/commands/import_area_countries.py
+++ b/hub/management/commands/import_area_countries.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
             defaults={
                 "data_type": "text",
                 "description": "The country that the constituency is in",
-                "label": "Country",
+                "label": "Country of the UK",
                 "source_label": "MapIt",
                 "source": "https://mapit.mysociety.org/",
                 "table": "areadata",

--- a/hub/management/commands/import_brexit_votes.py
+++ b/hub/management/commands/import_brexit_votes.py
@@ -17,8 +17,8 @@ class Command(BaseImportFromDataFrameCommand):
     data_sets = {
         "brexit_votes": {
             "defaults": {
-                "label": "Voted to leave the EU",
-                "description": "Percentage of people who voted to leave the EU in the 2016 referendum",
+                "label": "EU (Brexit) leave vote percentage",
+                "description": "Percentage of constituents who voted to leave the EU in the 2016 referendum",
                 "data_type": "percent",
                 "category": "opinion",
                 "source_label": "UK Parliament",

--- a/hub/management/commands/import_cen_nzsg_members.py
+++ b/hub/management/commands/import_cen_nzsg_members.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             defaults={
                 "data_type": "bool",
                 "description": "Conservative Environment Network membership",
-                "label": "Conservative Environment Network Member",
+                "label": "MP membership of Conservative Environment Network (CEN)",
                 "source_label": "CEN, collated by mySociety",
                 "source": "https://www.cen.uk.com/our-caucus",
                 "table": "person__persondata",
@@ -42,7 +42,7 @@ class Command(BaseCommand):
             defaults={
                 "data_type": "bool",
                 "description": "Net Zero Scrutiny Group membership",
-                "label": "Net Zero Scrutiny Group Member",
+                "label": "MP membership of Net Zero Scrutiny Group (NZSG)",
                 "source_label": "collated by DeSmog",
                 "source": "https://www.desmog.com/net-zero-scrutiny-group/",
                 "table": "person__persondata",

--- a/hub/management/commands/import_mp_engagement.py
+++ b/hub/management/commands/import_mp_engagement.py
@@ -36,8 +36,8 @@ class Command(BaseCommand):
             name="net_zero_target",
             defaults={
                 "data_type": "string",
-                "description": "MPs who have signed the Net Zero Target open letter",
-                "label": "Net Zero Target open letter with The Climate Coalition",
+                "description": "MP signed The Climate Coalition’s 2019 Net Zero Target joint letter",
+                "label": "MP signed The Climate Coalition’s 2019 Net Zero Target joint letter",
                 "source_label": "The Climate Coalition",
                 "source": "https://www.theclimatecoalition.org/joint-letter-2019",
                 "table": "person__persondata",
@@ -57,8 +57,8 @@ class Command(BaseCommand):
             name="onshore_wind_energy",
             defaults={
                 "data_type": "string",
-                "description": "MPs who have signed the Onshore Wind Energy open letter",
-                "label": "Onshore Wind Energy open letter with Possible",
+                "description": "MP signed Possible’s Onshore Wind Energy open letter",
+                "label": "MP signed Possible’s 2019 Onshore Wind Energy open letter",
                 "source_label": "Possible",
                 "source": "https://www.wearepossible.org/onshore-wind/latest/open-letter-from-mps-to-the-prime-minister",
                 "table": "person__persondata",

--- a/hub/management/commands/import_mps.py
+++ b/hub/management/commands/import_mps.py
@@ -75,12 +75,12 @@ class Command(BaseCommand):
     def import_mps(self):
         data = self.get_mp_data()
         type_names = {
-            "parlid": {"label": "Parliament ID"},
-            "twfyid": {"label": "TheyWorkForYou ID"},
-            "twitter": {"label": "Twitter username"},
-            "facebook": {"label": "Facebook username"},
-            "wikipedia": {"label": "Wikipedia article"},
-            "party": {"label": "Political Party"},
+            "parlid": {"label": "MP Parliament ID"},
+            "twfyid": {"label": "MP TheyWorkForYou ID"},
+            "twitter": {"label": "MP Twitter username"},
+            "facebook": {"label": "MP Facebook username"},
+            "wikipedia": {"label": "MP Wikipedia article"},
+            "party": {"label": "MP party"},
         }
         data_types = {}
         if not self._quiet:

--- a/hub/management/commands/import_mps_appg_data.py
+++ b/hub/management/commands/import_mps_appg_data.py
@@ -78,7 +78,7 @@ class Command(BaseCommand):
             defaults={
                 "data_type": "text",
                 "description": "Membership in APPGs as published on the parliament website",
-                "label": "APPG membership",
+                "label": "MP APPG memberships",
                 "source_label": "UK Parliament",
                 "source": "https://parliament.uk/",
                 "table": "person__persondata",

--- a/hub/management/commands/import_mps_relevant_votes.py
+++ b/hub/management/commands/import_mps_relevant_votes.py
@@ -153,8 +153,8 @@ class Command(BaseCommand):
                 name=vote_machine_name,
                 defaults={
                     "data_type": "string",
-                    "description": f"Member votes on {vote['vote_name']}",
-                    "label": vote["vote_name"],
+                    "description": f"MP vote on {vote['vote_name']}",
+                    "label": f"MP vote on {vote['vote_name']}",
                     "source_label": "UK Parliament",
                     "source": "https://parliament.uk/",
                     "table": "person__persondata",
@@ -176,8 +176,8 @@ class Command(BaseCommand):
                     name=edm_machine_name,
                     defaults={
                         "data_type": "string",
-                        "description": f"Supporters of {edm['edm_name']}",
-                        "label": edm["edm_name"],
+                        "description": f"MP support for {edm['edm_name']}",
+                        "label": f"MP support for {edm['edm_name']}",
                         "source_label": "UK Parliament",
                         "source": "https://parliament.uk/",
                         "table": "person__persondata",

--- a/hub/management/commands/import_mps_select_committee_membership.py
+++ b/hub/management/commands/import_mps_select_committee_membership.py
@@ -53,8 +53,8 @@ class Command(BaseCommand):
             name="select_committee_membership",
             defaults={
                 "data_type": "text",
-                "description": "MP membership in Select Committees",
-                "label": "Select Committee membership",
+                "description": "Membership in Select Committees as published on the parliament website",
+                "label": "MP Select Committee memberships",
                 "source_label": "UK Parliament",
                 "source": "https://parliament.uk/",
                 "table": "person__persondata",

--- a/hub/management/commands/import_onward_polling_data.py
+++ b/hub/management/commands/import_onward_polling_data.py
@@ -109,7 +109,7 @@ class Command(BaseImportFromDataFrameCommand):
         return df
 
     def get_label(self, defaults):
-        return defaults["col"]
+        return defaults["col"].capitalize()
 
     def delete_data(self):
         AreaData.objects.filter(data_type__in=self.data_types.values()).delete()

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -52,9 +52,9 @@
                     <div class="row row-cols-1 row-cols-md-2 g-4 mb-4">
                         <div class="col d-flex flex-column">
 
-                            {% include 'hub/area/_mrp_data.html' with dataset=indexed_categories.opinion.hnh_mrp_29 row_height=65 %}
+                            {% include 'hub/area/_mrp_data.html' with dataset=indexed_categories.opinion.hnh_mrp_29 row_height=85 %}
 
-                            {% include 'hub/area/_mrp_data.html' with dataset=indexed_categories.opinion.hnh_mrp_37_1 %}
+                            {% include 'hub/area/_mrp_data.html' with dataset=indexed_categories.opinion.hnh_mrp_37_1 row_height=65 %}
 
                             <div class="card flex-grow-1 dataset-card">
                                 <div class="dataset-card-header">
@@ -129,7 +129,8 @@
                         </div>
                         <div class="col d-flex flex-column">
 
-                            {% include 'hub/area/_mrp_data.html' with dataset=indexed_categories.opinion.hnh_mrp_24_3 %}
+                            {% include 'hub/area/_mrp_data.html' with dataset=indexed_categories.opinion.hnh_mrp_24_3 row_height=65 %}
+
                             <div class="card flex-grow-1 dataset-card">
                                 <div class="dataset-card-header pe-3">
                                     <h5>Support renewable energy projects in their local area</h5>

--- a/hub/templates/hub/area/_mrp_data.html
+++ b/hub/templates/hub/area/_mrp_data.html
@@ -6,7 +6,7 @@
         <h5>{{ dataset.label }}</h5>
     </div>
     <div class="card-body">
-        <table class="table mb-0 js-chart" data-chart-type="bar" data-chart-direction="y" data-row-height="{{ row_height}}">
+        <table class="table mb-0 js-chart" data-chart-type="bar" data-chart-direction="y" data-row-height="{{ row_height }}">
             <thead>
                 <tr>
                     <th scope="col">Response</th>
@@ -26,6 +26,6 @@
         </table>
     </div>
     <div class="card-footer bg-white">
-        <p class="card-text fs-8"><a href="#" class="text-decoration-none text-muted">Data from Focaldata 2023 MRP polling for HOPE not hate</a></p>
+        <p class="card-text fs-8 text-muted">Data from Focaldata 2023 MRP polling for HOPE not hate. <strong class="text-danger">Not to be publicly shared</strong></p>
     </div>
 </div>


### PR DESCRIPTION
Part of #192.

- Standardise wording for dataset names.
- Add data sharing warning to MRP datasets on area page.

@struan, once this is merged, is there a script we can run to update all the dataset names on the live site, or should I go in and edit them by hand via the Django admin?