### PR TITLE
handle shader value being equal to min correctly

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -238,6 +238,8 @@ class DataSet(TypeMixin, models.Model):
             x = 0.5  # cmax == cmin
 
         shade = int(x * 9) - 1
+        if shade < 0:
+            shade = 0
         return self.shades[shade]
 
     def colours_for_areas(self, areas):


### PR DESCRIPTION
If the shader value was the same as the min it meant the shader value ended up being -1 which then set the shade to the maximum because -1 gives the end element in the array

Fixes #245