### PR TITLE
MP changes no longer causes multiple MPs to an area

### DIFF
--- a/hub/fixtures/duplicate_mps.json
+++ b/hub/fixtures/duplicate_mps.json
@@ -1,0 +1,110 @@
+[
+    {
+      "model": "hub.person",
+      "pk": 1,
+      "fields": {
+        "name": "James Madeupname",
+        "external_id": "1",
+        "person_type": "MP",
+        "id_type": "parlid",
+        "area": 1
+      }
+    },
+    {
+      "model": "hub.person",
+      "pk": 2,
+      "fields": {
+        "name": "Juliet Madeupname",
+        "external_id": "2",
+        "person_type": "MP",
+        "id_type": "parlid",
+        "area": 2
+      }
+    },
+    {
+        "model": "hub.person",
+        "pk": 3,
+        "fields": {
+          "name": "Juliet Replacement",
+          "external_id": "3",
+          "person_type": "MP",
+          "id_type": "parlid",
+          "area": 2
+        }
+    },
+    {
+        "model": "hub.area",
+        "pk": 1,
+        "fields": {
+          "gss": "E10000001",
+          "mapit_id": "1",
+          "name": "South Borsetshire",
+          "area_type": "WMC",
+          "geometry": "{\"name\": \"South Borsetshire\", \"properties\": {}}"
+        }
+      },
+      {
+        "model": "hub.area",
+        "pk": 2,
+        "fields": {
+          "gss": "E10000002",
+          "mapit_id": "2",
+          "name": "North Borsetshire",
+          "area_type": "WMC",
+          "geometry": "{\"name\": \"North Borsetshire\", \"properties\": {}}"
+        }
+      },
+      {
+        "model": "hub.dataset",
+        "pk": 1,
+        "fields": {
+          "name": "mp_last_elected",
+          "data_type": "date",
+          "last_update": "2022-10-10T13:20:30+00:00",
+          "source": "https://wikipedia.org",
+          "table": "person__persondata"
+        }
+      },
+      {
+        "model": "hub.datatype",
+        "pk": 1,
+        "fields": {
+          "data_set": 1,
+          "name": "mp_last_elected",
+          "data_type": "date",
+          "last_update": "2022-10-10T13:20:30+00:00"
+        }
+      },
+      {
+        "model": "hub.persondata",
+        "pk": 1,
+        "fields": {
+          "person": 1,
+          "data_type": 1,
+          "data": "",
+          "date": "2005-04-05T00:00:00+00:00"
+        }
+      },
+      {
+        "model": "hub.persondata",
+        "pk": 2,
+        "fields": {
+          "person": 2,
+          "data_type": 1,
+          "data": "",
+          "date": "2005-05-05T00:00:00+00:00"
+        }
+      },
+      {
+        "model": "hub.persondata",
+        "pk": 3,
+        "fields": {
+          "person": 3,
+          "data_type": 1,
+          "data": "",
+          "date": "2019-12-12T00:00:00+00:00"
+        }
+      }
+  ]
+  
+  


### PR DESCRIPTION
Fixes #225

When the import_mps command is ran, if a new MP had been elected in that time, it would add them to the database without removing the previous MP. This means that when you navigate to the relevant constituency webpage, it would return a MultipleObjectsReturned error.

Now, the script will identify multiple MPs to an area, and then keep only the most recently elected one. It will then re-run all of the MP data scripts, so that the information for the MP is populated.

Currently, the way that the `PersonData` imports are identified is by hard-coding the command names into a constant. Possibly, it might be a better solution to search for filenames with a specific prefix (e.g. `mp_data_datasetname`), but this could cause unnecessary confusion in future development.

Additionally, the script will run the _entire_ commands, not just for a specific MP (particularly because many of them will read from a CSV, or pull data from an API in bulk. It's possible, but might be unnecessary, to refactor some of these so that an argument can be passed to the command that will return the data for only that MP.