### PR TITLE
Account page improvements

### DIFF
--- a/hub/templates/hub/accounts/accounts.html
+++ b/hub/templates/hub/accounts/accounts.html
@@ -84,7 +84,6 @@
                     <th scope="col">Name</th>
                     <th scope="col">Organisation</th>
                     <th scope="col">Status</th>
-                    <th scope="col">Staff</th>
                     <th scope="col">Joined</th>
                     <th scope="col">Last seen</th>
                 </tr>
@@ -94,6 +93,11 @@
                 <tr>
                     <td>
                         <a href="{% url 'admin:hub_userproperties_change' user.pk %}">{{ user.full_name }}</a>
+                      {% if user.user.is_superuser %}
+                        <span class="badge text-bg-yellow-500 fs-9 ms-1" style="vertical-align: 0.1em">Superuser</span>
+                      {% elif user.user.is_staff %}
+                        <span class="badge text-bg-cyan-300 fs-9 ms-1" style="vertical-align: 0.1em">Staff</span>
+                      {% endif %}
                     </td>
                     <td>
                         {{ user.organisation_name }}
@@ -107,13 +111,6 @@
                             Awaiting activation
                         {% else %}
                             Unconfirmed email
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if user.user.is_superuser %}
-                            Superuser
-                        {% elif user.user.is_staff %}
-                            Staff
                         {% endif %}
                     </td>
                     <td>

--- a/hub/templates/hub/accounts/accounts.html
+++ b/hub/templates/hub/accounts/accounts.html
@@ -114,10 +114,10 @@
                         {% endif %}
                     </td>
                     <td>
-                        {{ user.user.date_joined|date:"j M Y" }}
+                        {{ user.user.date_joined|date:"jS F" }}
                     </td>
                     <td>
-                        {{ user.last_seen|date:"j M Y" }}
+                        {{ user.last_seen|date:"jS F" }}
                     </td>
                 </tr>
             {% endfor %}

--- a/hub/views/accounts.py
+++ b/hub/views/accounts.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.views import LoginView
+from django.db.models import F
 from django.shortcuts import redirect, reverse
 from django.views.generic import FormView, TemplateView
 
@@ -82,7 +83,7 @@ class AccountsView(PermissionRequiredMixin, TitleMixin, FormView):
 
         users = UserProperties.objects.all()
 
-        context["users"] = users.order_by("last_seen")
+        context["users"] = users.order_by(F("last_seen").desc(nulls_last=True))
         context["count_users_seen_this_week"] = users.filter(
             last_seen__gte=time_a_week_ago
         ).count()


### PR DESCRIPTION
Fixes most of #253.

- Sort users on `/accounts` most recently seen at the top
- Display staff status as badge not column, on `/accounts` page
- Simpler date formatting for dates on `/accounts` page
