### PR TITLE
skip shading if filters return no areas

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -257,6 +257,9 @@ class DataSet(TypeMixin, models.Model):
         return self.shades[shade]
 
     def colours_for_areas(self, areas):
+        if len(areas) == 0:
+            return {"properties": {"no_areas": True}}
+
         values, mininimum, maximum = self.shader_value(areas)
         legend = {}
         for option in self.options:
@@ -289,7 +292,6 @@ class DataSet(TypeMixin, models.Model):
             data = value.value()
             for option in self.options:
                 if option["title"] == data:
-                    print(data, option["shader"])
                     colours[value.gss] = {
                         "colour": self.COLOUR_NAMES.get(
                             option["shader"], option["shader"]

--- a/hub/static/js/explore.esm.js
+++ b/hub/static/js/explore.esm.js
@@ -14,6 +14,7 @@ const app = createApp({
       columns: [],
       shader: null,
       key: null,
+      no_areas: false,
       legend: null,
       view: 'map',
       map: null,
@@ -158,6 +159,7 @@ const app = createApp({
       this.shader = null
       this.key = null
       this.legend = null
+      this.no_areas = null
     },
     toggleBrowseDatasets() {
       this.browseDatasets = !this.browseDatasets
@@ -306,9 +308,12 @@ const app = createApp({
           }).addTo(this.map)
           this.key = null
           this.legend = null
+          this.no_areas = null
           if ("properties" in data && data["properties"]) {
             var p = data["properties"]
-            if ("legend" in p) {
+            if ("no-areas" in p) {
+              this.no_areas = true
+            } else if ("legend" in p) {
               this.legend = p["legend"]
             } else {
               this.key = p
@@ -352,9 +357,12 @@ const app = createApp({
 
           this.key = null
           this.legend = null
+          this.no_areas = false
           if ("properties" in data && data["properties"]) {
             var p = data["properties"]
-            if ("legend" in p) {
+            if ("no_areas" in p) {
+              this.no_areas = true
+            } else if ("legend" in p) {
               this.legend = p["legend"]
             } else {
               this.key = p

--- a/hub/templates/hub/explore.html
+++ b/hub/templates/hub/explore.html
@@ -72,6 +72,11 @@
                                 <h3 class="h6 mb-0 me-auto">${ shader.title }</h3>
                                 <button @click="removeShader(shader.name)" type="button" class="btn-close p-0" aria-label="Remove shader"></button>
                             </div>
+                            <ul v-if="no_areas" class="mt-3 mb-0 list-unstyled fs-7 lh-1 text-muted">
+                                <li class="d-flex align-items-center mt-1">
+                                    No areas to display
+                                </li>
+                            </ul>
                             <ul v-if="legend" class="mt-3 mb-0 list-unstyled fs-7 lh-1 text-muted">
                                 <li v-for="(shade, title) in legend" class="d-flex align-items-center mt-1">
                                     <span :style="`background-color: ${ shade }`" class="d-block ps-3 pt-3 me-2"></span>


### PR DESCRIPTION
Display a message in place of the key/scale to make it clear.

This avoids an error when trying to round the None value returned for max/min if there are no areas.

Fixes #266