### PR TITLE
Add cookieless GA4 boilerplate

### DIFF
--- a/hub/templates/hub/base.html
+++ b/hub/templates/hub/base.html
@@ -27,14 +27,14 @@
     <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">
   {% endif %}
   {% if GOOGLE_ANALYTICS %}
-    <script defer>var capturedCookies={};Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);for(var e in capturedCookies)t+=" "+e+"="+capturedCookies[e]+";";return t},set:function(t){var e=t.split("="),o=e[0].trim(),r=e[1].trim();o.startsWith("_ga")?capturedCookies[o]=r:Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
+    <script defer>Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
     <script defer src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS }}"></script>
     <script>
         var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config','{{ GOOGLE_ANALYTICS }}', {'client_id': client_id, 'cookie_expires': 0 });
+        gtag('config','{{ GOOGLE_ANALYTICS }}', {'client_id': client_id, 'cookie_expires': 1 });
     </script>
   {% endif %}
     <script type="module">document.documentElement.classList.remove('no-js'); document.documentElement.classList.add('js');</script>

--- a/hub/templates/hub/base.html
+++ b/hub/templates/hub/base.html
@@ -27,19 +27,14 @@
     <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">
   {% endif %}
   {% if GOOGLE_ANALYTICS %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS }}"></script>
+    <script defer>var capturedCookies={};Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);for(var e in capturedCookies)t+=" "+e+"="+capturedCookies[e]+";";return t},set:function(t){var e=t.split("="),o=e[0].trim(),r=e[1].trim();o.startsWith("_ga")?capturedCookies[o]=r:Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
+    <script defer src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS }}"></script>
     <script>
+        var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', '{{ GOOGLE_ANALYTICS }}');
-        gtag("consent", "default", {
-            ad_storage: "denied",
-            analytics_storage: "denied",
-            functionality_storage: "denied",
-            personalization_storage: "denied",
-            security_storage: "denied"
-        });
+        gtag('config','{{ GOOGLE_ANALYTICS }}', {'client_id': client_id, 'cookie_expires': 0 });
     </script>
   {% endif %}
     <script type="module">document.documentElement.classList.remove('no-js'); document.documentElement.classList.add('js');</script>


### PR DESCRIPTION
Implement cookieless GA4 approach 

See: https://docs.google.com/document/u/1/d/1ZXbkXoLE0eLnUWJaVv_8xpnVOlOHGCxPP_Uo7cfoFJo/edit

- Capture and prevent _ga cookies being written
- Give manual random client_id per page view