### PR TITLE
fix issue with populating filter values from url

### DIFF
--- a/hub/static/js/explore.esm.js
+++ b/hub/static/js/explore.esm.js
@@ -225,7 +225,7 @@ const app = createApp({
           const name = key.slice(0, index)
           const comparator = key.slice(index + 2)
           const is_in = key.indexOf('__in')
-          var value = v
+          const value = v
           if ( is_in > 0 ) {
             value = value.split(',')
           }


### PR DESCRIPTION
If there was more than one filter in the URL state then they were all being assigned the same value due to a JS scoping issue