### PR TITLE
explore.csv with no filters returns just constituency names

### DIFF
--- a/hub/mixins.py
+++ b/hub/mixins.py
@@ -142,6 +142,15 @@ class FilterMixin:
         cols.extend(self.columns(mp_name=mp_name))
 
         """
+        shortcut if no filters/columns were requested: just return a single
+        column of constituency names
+        """
+        if not cols:
+            for area in Area.objects.order_by("name"):
+                data.append([area.name])
+            return data
+
+        """
         first for each column we want gather the data and store it against the
         area
         """


### PR DESCRIPTION
This resolves an inconsistency between how the map (explore.json) and table (explore.csv) handled requests without any filters/shaders.

Previously, if a user loaded the /explore page, it would default to a map with 650 constituencies displayed. But if they switched to the table view (without modifying any filters!) all those constituencies would disappear and the table would be empty.

![Screenshot 2023-07-21 at 17-21-35 Explore Local Intelligence Hub](https://github.com/mysociety/local-intelligence-hub/assets/739624/596da66a-363d-4381-8624-831c6d171d15)

Essentially, the table contradicted the mental model of the /explore page: that we are "filtering" down from a big list of constituencies to a smaller one.

This became particularly jarring with the new status display in #292. Switching from map to table view would alternate between "650 constituencies" and "No constituencies". Yuck.

![Screenshot 2023-07-21 at 17-23-09 Explore Local Intelligence Hub](https://github.com/mysociety/local-intelligence-hub/assets/739624/0b64fc4d-ee74-412e-8a68-346164ccfe7e)

Since the table draws its data from explore.csv, I modified `FilterMixin.data()` to return something different (a list of just consituency names) if no filters or custom columns were requested.

As a result, the table will _always_ contain at least a single column of constituency names, making the table UX consistent with the map.