### PR TITLE
Define MP majorities as person__persondata, not areadata

### DIFF
--- a/hub/management/commands/import_mps_election_results.py
+++ b/hub/management/commands/import_mps_election_results.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
                 "source": "https://members-api.parliament.uk/",
                 "source_label": "UK Parliament",
                 "comparators": DataSet.numerical_comparators()[::-1],
-                "table": "areadata",
+                "table": "person__persondata",
                 "default_value": 1000,
             },
         )


### PR DESCRIPTION
Setting "table: areadata" for MP majorities in the MP election results import script (but then actually _saving_ the datapoints as PersonData) was causing any Explore page query containing a filter or shader on MP majority to return zero results.