### PR TITLE
add update_averages call to importers missing it

### DIFF
--- a/hub/management/commands/import_christian_aid_group_locations.py
+++ b/hub/management/commands/import_christian_aid_group_locations.py
@@ -67,6 +67,7 @@ class Command(BaseAreaImportCommand):
         self.add_data_sets()
         self.delete_data()
         self.process_data()
+        self.update_averages()
         self.update_max_min()
 
     def add_to_dict(self, df):

--- a/hub/management/commands/import_wi_group_locations.py
+++ b/hub/management/commands/import_wi_group_locations.py
@@ -67,6 +67,7 @@ class Command(BaseAreaImportCommand):
         self.add_data_sets()
         self.delete_data()
         self.process_data()
+        self.update_averages()
         self.update_max_min()
 
     def process_data(self):


### PR DESCRIPTION
Some importers were not calculating an average value which meant there was no default value when a filter was selected.

Fixes #327