### PR TITLE
Updates to the Privacy Policy, and self-service account deletion

### DIFF
--- a/hub/templates/hub/accounts/my_account.html
+++ b/hub/templates/hub/accounts/my_account.html
@@ -1,0 +1,41 @@
+{% extends "hub/base.html" %}
+
+{% block content %}
+
+<div class="py-4 py-lg-5">
+    <div class="container">
+        <div class="d-flex mb-4 mb-lg-5 align-items-center">
+            <h1 class="mb-0 me-auto">Your account</h1>
+            <a href="{% url 'logout' %}" class="btn btn-danger text-nowrap">Sign out</a>
+        </div>
+
+        <div class="readable mb-5 mb-lg-6">
+            <dl class="row">
+                <dt class="col-sm-3">Full name</dt>
+                <dd class="col-sm-9">{{ request.user.userproperties.full_name }}</dd>
+                <dt class="col-sm-3">Organisation</dt>
+                <dd class="col-sm-9">{{ request.user.userproperties.organisation_name }}</dd>
+                <dt class="col-sm-3">Email</dt>
+                <dd class="col-sm-9">{{ request.user.email }}</dd>
+            </dl>
+            <p>If you need to change these details, please <a href="{% url 'contact' %}">contact us</a>.</p>
+            <p>You can also <a href="{% url 'password_reset' %}">change your password</a>.</p>
+        </div>
+
+        <div class="p-3 p-lg-4 rounded bg-red-100 mb-4">
+            <h2 class="h3 mb-3 mb-lg-4">Danger zone</h2>
+            <div class="d-md-flex align-items-center">
+                <div class="flex-grow-1 mb-3 mb-md-0 pe-sm-5">
+                    <h3 class="h6">Delete your account</h3>
+                    <p class="mb-0">If you no longer need your account, you can delete it. This <strong>cannot</strong> be undone.</p>
+                </div>
+                <form method="post">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-danger text-nowrap">Delete account immediately</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/hub/templates/hub/includes/header.html
+++ b/hub/templates/hub/includes/header.html
@@ -7,11 +7,11 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav ms-auto">
+            <ul class="navbar-nav ms-auto flex-wrap justify-content-end">
               {% if user.is_authenticated %}
                 {% include 'hub/includes/nav-item.html' with name='home' label='Search' %}
                 {% include 'hub/includes/nav-item.html' with name='explore' label='Map' %}
-                {% include 'hub/includes/nav-item.html' with name='logout' label='Sign out' %}
+                {% include 'hub/includes/nav-item.html' with name='my_account' label='Account' %}
               {% else %}
                 {% include 'hub/includes/nav-item.html' with name='login' label='Sign in' %}
               {% endif %}

--- a/hub/templates/hub/privacy.html
+++ b/hub/templates/hub/privacy.html
@@ -33,7 +33,7 @@
 
             <h2 id="legal-basis">Legal basis for processing</h2>
 
-            <p>When you request a personal account on the site, you are consenting to the processes as described on this page. The legal basis is GDPR 6(1)(a) Consent of the data subject.</p>
+            <p>When you request a personal account on the site, you are consenting to the processes as described on this page. The legal basis is GDPR 6(1)(a) Consent of the data subject. You can withdraw this consent at any time by <a href="#erasure">deleting your account</a>.</p>
 
             <p>If you are an MP, and your information has been used on the site, this is being stored under the legal basis of GDPR 6(1)(f) Legitimate interests. In our assessment, this is already public information about MPs, with a minimal privacy impact, being used in a way that MPs should reasonably expect, to provide a public benefit – transparency on what MPs do as part of their public role.</p>
 
@@ -55,7 +55,7 @@
 
             <h2 id="erasure">Your right to erasure</h2>
 
-            <p>You may request that we destroy the personal data that we hold about you. <a href="{% url 'contact' %}">Please email us</a> to request this.</p>
+            <p><strong>If you have an account on the site</strong> you can delete it via the <a href="{% url 'my_account' %}">Your account</a> page.</p>
 
             <h2 id="object">Your right to object</h2>
 

--- a/hub/templates/hub/privacy.html
+++ b/hub/templates/hub/privacy.html
@@ -37,9 +37,13 @@
 
             <p>If you are an MP, and your information has been used on the site, this is being stored under the legal basis of GDPR 6(1)(f) Legitimate interests. In our assessment, this is already public information about MPs, with a minimal privacy impact, being used in a way that MPs should reasonably expect, to provide a public benefit – transparency on what MPs do as part of their public role.</p>
 
+            <p>When you interact with this site, information about the visit stored in our web server logs is stored under the basis of GDPR 6(1)(f) Legitimate interests. We collect this in order to analyse usage of the site, facilitate debugging and prevent abuse.</p>
+
             <h2 id="retention">How long we keep your data</h2>
 
             <p>In all cases listed above, we retain your personal data until such a time as it is removed from our upstream data sources (listed here) or you ask us to remove your details.</p>
+
+            <p> As stated above, we retain information logged in our web server logs for 28 days.</p>
 
             <h2 id="sharing">Who we share your data with</h2>
 

--- a/hub/templates/hub/privacy.html
+++ b/hub/templates/hub/privacy.html
@@ -57,6 +57,10 @@
 
             <p>You may request that we destroy the personal data that we hold about you. <a href="{% url 'contact' %}">Please email us</a> to request this.</p>
 
+            <h2 id="object">Your right to object</h2>
+
+            <p>You have the right to object to our processing of your personal data. <a href="{% url 'contact' %}">Please email us</a> to request this.</p>
+
             <h2 id="complain">Your right to complain</h2>
 
             <p>If you believe that we have mishandled your data, you have the right to lodge a complaint with the Information Commissioner’s Office. <a href="https://ico.org.uk/concerns/handling/">You can report a concern here</a> (but do please <a href="{% url 'contact' %}">email us first</a>, so that we can try and help).</p>

--- a/hub/views/accounts.py
+++ b/hub/views/accounts.py
@@ -1,12 +1,14 @@
 import csv
 from datetime import date, timedelta
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.views import LoginView
 from django.db.models import F
 from django.http import HttpResponse
 from django.shortcuts import redirect, reverse
-from django.views.generic import FormView, ListView, TemplateView
+from django.urls import reverse_lazy
+from django.views.generic import DeleteView, FormView, ListView, TemplateView
 
 from hub.forms import ActivateUserFormSet, InactiveCheckLoginForm, SignupForm
 from hub.mixins import TitleMixin
@@ -146,3 +148,13 @@ class AccountsCSV(PermissionRequiredMixin, ListView):
                 }
             )
         return response
+
+
+class MyAccountView(TitleMixin, DeleteView):
+    page_title = "Your account"
+    model = get_user_model()
+    template_name = "hub/accounts/my_account.html"
+    success_url = reverse_lazy("home")
+
+    def get_object(self, queryset=None):
+        return self.request.user

--- a/local_intelligence_hub/urls.py
+++ b/local_intelligence_hub/urls.py
@@ -57,6 +57,7 @@ urlpatterns = [
     path("location/", area.AreaSearchView.as_view(), name="area_search"),
     path("style/", core.StyleView.as_view(), name="style"),
     path("status/", core.StatusView.as_view(), name="status"),
+    path("me/", accounts.MyAccountView.as_view(), name="my_account"),
     path("signup/", accounts.SignupView.as_view(), name="signup"),
     path(
         "confirmation_sent/",


### PR DESCRIPTION
Some small updates to ensure that we specify we're collecting web server logs under legitimate interest and to include the right to object.

Plus a new "Your account" page (`/me`) featuring a "Delete account" button that immediately deletes the user’s account (and associated `UserProperties` object).

Fixes #321.

Fixes #319.

![Screenshot 2023-12-08 at 13-56-04 Your account Local Intelligence Hub](https://github.com/mysociety/local-intelligence-hub/assets/739624/be94ec87-52b1-4680-818d-3d8e18b093af)
