### PR TITLE
Snagging fix: Styling of new/old constituency replacement message on area page

### DIFF
--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -31,8 +31,13 @@
           {% if overlap_constituencies|length > 1 %}
             <p class="text-muted">At the next election, this constituency will be divided into <b>{{ overlap_constituencies|length|apnumber }} new constituenc{% if overlap_constituencies|length_is:1 %}y{% else %}ies{% endif %}:</b></p>
           {% else %}
+            {% if overlap_unchanged %}
+            <p class="text-muted">Looking for data on Prospective Parliamentary Candidates at the next general election?{% with overlap_constituencies|first as cons %} See the <a href="{% url 'area' area_type=cons.new_area.area_type.code name=cons.new_area.name %}">future constituency</a>.{% endwith %}</p>
+            {% else %}
             <p class="text-muted">At the next election, this constituency will be replaced with:</p>
+            {% endif %}
           {% endif %}
+          {% if not overlap_unchanged %}
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); grid-gap: 1rem 2rem;">
               {% for overlap_constituency in overlap_constituencies %}
                 <div>
@@ -41,14 +46,20 @@
                 </div>
               {% endfor %}
             </div>
+          {% endif %}
         </div>
       {% elif area_type == "WMC23" and area.overlaps %}
         <div style="max-width: 48rem;" class="mt-4 pt-lg-2">
           {% if overlap_constituencies|length > 1 %}
-            <p class="text-muted">This constituency will only exist at the next election, and replaces the previous <b>{{ overlap_constituencies|length|apnumber }} new constituenc{% if overlap_constituencies|length_is:1 %}y{% else %}ies{% endif %}:</b></p>
+            <p class="text-muted">This constituency will only exist at the next election, and replaces the previous <b>{{ overlap_constituencies|length|apnumber }} constituenc{% if overlap_constituencies|length_is:1 %}y{% else %}ies{% endif %}:</b></p>
           {% else %}
+            {% if overlap_unchanged %}
+            <p class="text-muted">Looking for data on this constituency’s current MP? {% with overlap_constituencies|first as cons %} See the <a href="{% url 'area' area_type=cons.old_area.area_type.code name=cons.old_area.name %}">current constituency</a>.{% endwith %}</p>
+            {% else %}
             <p class="text-muted">This constituency will only exist at the next election, and replaces:</p>
+            {% endif %}
           {% endif %}
+          {% if not overlap_unchanged %}
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); grid-gap: 1rem 2rem;">
               {% for overlap_constituency in overlap_constituencies %}
                 <div>
@@ -57,6 +68,7 @@
                 </div>
               {% endfor %}
             </div>
+          {% endif %}
         </div>
       {% endif %}
     </div>

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -18,47 +18,6 @@
                 <p class="mb-0 text-muted">Future parliamentary constituency</p>
                 {% endif %}
             </div>
-            <div class="col-lg-9 offset-xl-1">
-              {% if area_type == "WMC" and area.overlaps %}
-                <div class="card flex-grow-1">
-                    <div class="card-body">
-                      {% if overlap_constituencies|length > 1 %}
-                        <p>At the next election, this constituency will be divided into <b>{{ overlap_constituencies|length|apnumber }} new constituenc{% if overlap_constituencies|length_is:1 %}y{% else %}ies{% endif %}:</b></p>
-                      {% else %}
-                        <p>At the next election, this constituency will be replaced with:</p>
-                      {% endif %}
-                        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); grid-gap: 1rem 2rem;">
-                          {% for overlap_constituency in overlap_constituencies %}
-                            <div>
-                                <h3 class="h5"><a href="{% url 'area' area_type=overlap_constituency.new_area.area_type.code name=overlap_constituency.new_area.name %}" class="text-decoration-none">{{ overlap_constituency.new_area }}</a></h3>
-                                <p class="fs-7 text-muted mb-0">Will cover approximately {{ overlap_constituency.pop_overlap }}% of this constituency’s population, and {{ overlap_constituency.area_overlap }}% of this constituency’s area.</p>
-                            </div>
-                          {% endfor %}
-                        </div>
-                    </div>
-                </div>
-              {% elif area_type == "WMC23" and area.overlaps %}
-                <div class="card flex-grow-1">
-                  {% if area.overlaps %}
-                    <div class="card-body">
-                      {% if overlap_constituencies|length > 1 %}
-                        <p>This constituency will only exist at the next election, and replaces the previous <b>{{ overlap_constituencies|length|apnumber }} constituenc{% if overlap_constituencies|length_is:1 %}y{% else %}ies{% endif %}:</b></p>
-                      {% else %}
-                        <p>This constituency will only exist at the next election, and replaces:</p>
-                      {% endif %}
-                        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); grid-gap: 1rem 2rem;">
-                          {% for overlap_constituency in overlap_constituencies %}
-                            <div>
-                                <h3 class="h5"><a href="{% url 'area' area_type=overlap_constituency.old_area.area_type.code name=overlap_constituency.old_area.name %}" class="text-decoration-none">{{ overlap_constituency.old_area }}</a></h3>
-                                <p class="fs-7 text-muted mb-0">Covered approximately {{ overlap_constituency.pop_overlap }}% of this constituency’s population, and {{ overlap_constituency.area_overlap }}% of this constituency’s area.</p>
-                            </div>
-                          {% endfor %}
-                        </div>
-                    </div>
-                  {% endif %}
-                </div>
-              {% endif %}
-            </div>
 
             {% comment %} TODO: Make this share button work {% endcomment %}
             {% comment %} <button class="btn btn-primary d-flex align-items-center gap-2">
@@ -66,6 +25,40 @@
                 Share this page
             </button> {% endcomment %}
         </div>
+
+      {% if area_type == "WMC" and area.overlaps %}
+        <div style="max-width: 48rem;" class="mt-4 pt-lg-2">
+          {% if overlap_constituencies|length > 1 %}
+            <p class="text-muted">At the next election, this constituency will be divided into <b>{{ overlap_constituencies|length|apnumber }} new constituenc{% if overlap_constituencies|length_is:1 %}y{% else %}ies{% endif %}:</b></p>
+          {% else %}
+            <p class="text-muted">At the next election, this constituency will be replaced with:</p>
+          {% endif %}
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); grid-gap: 1rem 2rem;">
+              {% for overlap_constituency in overlap_constituencies %}
+                <div>
+                    <h3 class="h5"><a href="{% url 'area' area_type=overlap_constituency.new_area.area_type.code name=overlap_constituency.new_area.name %}" class="text-decoration-none">{{ overlap_constituency.new_area }}</a></h3>
+                    <p class="fs-7 text-muted mb-0">Will cover approximately {{ overlap_constituency.pop_overlap }}% of this constituency’s population, and {{ overlap_constituency.area_overlap }}% of this constituency’s area.</p>
+                </div>
+              {% endfor %}
+            </div>
+        </div>
+      {% elif area_type == "WMC23" and area.overlaps %}
+        <div style="max-width: 48rem;" class="mt-4 pt-lg-2">
+          {% if overlap_constituencies|length > 1 %}
+            <p class="text-muted">This constituency will only exist at the next election, and replaces the previous <b>{{ overlap_constituencies|length|apnumber }} new constituenc{% if overlap_constituencies|length_is:1 %}y{% else %}ies{% endif %}:</b></p>
+          {% else %}
+            <p class="text-muted">This constituency will only exist at the next election, and replaces:</p>
+          {% endif %}
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); grid-gap: 1rem 2rem;">
+              {% for overlap_constituency in overlap_constituencies %}
+                <div>
+                    <h3 class="h5"><a href="{% url 'area' area_type=overlap_constituency.old_area.area_type.code name=overlap_constituency.old_area.name %}" class="text-decoration-none">{{ overlap_constituency.old_area }}</a></h3>
+                    <p class="fs-7 text-muted mb-0">Will cover approximately {{ overlap_constituency.pop_overlap }}% of this constituency’s population, and {{ overlap_constituency.area_overlap }}% of this constituency’s area.</p>
+                </div>
+              {% endfor %}
+            </div>
+        </div>
+      {% endif %}
     </div>
 </div>
 

--- a/hub/views/area.py
+++ b/hub/views/area.py
@@ -118,7 +118,7 @@ class AreaView(BaseAreaView):
         elif self.object.area_type.code == "WMC23":
             overlaps = self.object.new_overlaps.all()
         else:
-            return []
+            return None
 
         overlap_constituencies = [
             {
@@ -129,12 +129,24 @@ class AreaView(BaseAreaView):
             }
             for overlap in overlaps
         ]
+        if (
+            len(overlap_constituencies) == 1
+            and overlap_constituencies[0]["new_area"].gss
+            == overlap_constituencies[0]["old_area"].gss
+        ):
+            overlap_constituencies[0]["unchanged"] = True
         return overlap_constituencies
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
         context["overlap_constituencies"] = self.get_overlap_info()
+        if (
+            context["overlap_constituencies"] is not None
+            and len(context["overlap_constituencies"]) == 1
+        ):
+            if context["overlap_constituencies"][0].get("unchanged", False):
+                context["overlap_unchanged"] = True
         context["area_type"] = str(self.object.area_type)
         if context["area_type"] == "WMC23":
             context["PPCs"] = [


### PR DESCRIPTION
Part of #383 snagging.

![Screenshot 2024-01-12 at 12 33 55](https://github.com/mysociety/local-intelligence-hub/assets/739624/ca2ac8af-e3a3-4734-add5-9d5b4e9074ed)

@struan can you review this actually looks ok on both old and new area pages, on a host with real data? (My local database is a mess.)