### PR TITLE
Snagging fix: Rename "MP" tab to "PPCs" on WMC23 area pages

### DIFF
--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -82,7 +82,7 @@
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="#mp">MP</a>
+                <a class="nav-link" href="#mp">{% if area_type == "WMC23" %}PPCs{% else %}MP{% endif %}</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="#opinion">Public opinion</a>

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -12,7 +12,11 @@
         <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">
             <div>
                 <h1 class="mb-2">{{ area.name }}</h1>
+                {% if area_type == "WMC" %}
                 <p class="mb-0 text-muted">Current parliamentary constituency</p>
+                {% elif area_type == "WMC23" %}
+                <p class="mb-0 text-muted">Future parliamentary constituency</p>
+                {% endif %}
             </div>
             <div class="col-lg-9 offset-xl-1">
               {% if area_type == "WMC" and area.overlaps %}


### PR DESCRIPTION
Part of #383 snagging.

![Screenshot 2024-01-12 at 12 52 46](https://github.com/mysociety/local-intelligence-hub/assets/739624/12dcb8a0-d918-4f65-aa64-b387fff7e134)
