### PR TITLE
Snagging fix: Show release dates on Area and Explore pages

### DIFF
--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -339,7 +339,12 @@
                       {% endif %}
                     </div>
                     <div class="card-footer">
-                      <p class="card-text">{{ dataset.source }}</p>
+                      <p class="card-text">
+                          {{ dataset.source }}
+                        {% if dataset.release_date %}
+                          Updated {{ dataset.release_date }}.
+                        {% endif %}
+                      </p>
                     </div>
                 </div>
               {% endfor %}
@@ -408,7 +413,12 @@
                       {% endif %}
                     </div>
                     <div class="card-footer">
-                      <p class="card-text">{{ dataset.source }}</p>
+                      <p class="card-text">
+                          {{ dataset.source }}
+                        {% if dataset.release_date %}
+                          Updated {{ dataset.release_date }}.
+                        {% endif %}
+                      </p>
                     </div>
                 </div>
               {% endfor %}
@@ -500,7 +510,12 @@
                       {% endif %}
                     </div>
                     <div class="card-footer">
-                      <p class="card-text">{{ dataset.source }}</p>
+                      <p class="card-text">
+                          {{ dataset.source }}
+                        {% if dataset.release_date %}
+                          Updated {{ dataset.release_date }}.
+                        {% endif %}
+                      </p>
                     </div>
                 </div>
               {% endfor %}

--- a/hub/templates/hub/includes/add-data-modal-button.html
+++ b/hub/templates/hub/includes/add-data-modal-button.html
@@ -6,8 +6,8 @@
         </span>
     </div>
     <small class="d-block text-muted fs-8">
-        <template v-if="dataset.description">${ dataset.description }.</template>
-        Data from ${ dataset.source_label }.
+        <template v-if="dataset.description">${ dataset.description }</template>
+        ${ dataset.source_label }
+        <template v-if="dataset.release_date">Updated ${ dataset.release_date }.</template>
     </small>
 </button>
-

--- a/hub/views/area.py
+++ b/hub/views/area.py
@@ -74,6 +74,7 @@ class BaseAreaView(TitleMixin, DetailView):
             "data_type": data_set.data_type,
             "featured": data_set.featured,
             "excluded_countries": data_set.exclude_countries,
+            "release_date": data_set.release_date,
         }
         if data_set.is_range:
             data["is_range"] = True


### PR DESCRIPTION
Part of https://github.com/mysociety/local-intelligence-hub/issues/383 snagging.

<img width="456" alt="Screenshot 2024-01-15 at 10 15 30" src="https://github.com/mysociety/local-intelligence-hub/assets/739624/02e224d1-e342-4653-8387-1f49a2e5791a"><br>

<img width="277" alt="Screenshot 2024-01-15 at 10 24 46" src="https://github.com/mysociety/local-intelligence-hub/assets/739624/da63f81b-b9b7-4a83-9d1b-7a608920cdab">
