### PR TITLE
members only datasets frontend v2

### DIFF
--- a/hub/fixtures/area_data.json
+++ b/hub/fixtures/area_data.json
@@ -11,7 +11,8 @@
       "source": "https://parliament.uk",
       "table": "areadata",
       "areas_available": [1],
-      "category": "place"
+      "category": "place",
+      "is_public": "True"
     }
   },
   {

--- a/hub/fixtures/elections.json
+++ b/hub/fixtures/elections.json
@@ -8,7 +8,8 @@
       "last_update": "2022-10-10T13:20:30+00:00",
       "source": "https://wikipedia.org",
       "areas_available": [1],
-      "table": "person__persondata"
+      "table": "person__persondata",
+      "is_public": "True"
     }
   },
   {

--- a/hub/middleware.py
+++ b/hub/middleware.py
@@ -1,34 +1,8 @@
 from datetime import timedelta
 
-from django.conf import settings
-from django.http import HttpResponseRedirect
-from django.urls import reverse_lazy
 from django.utils.timezone import now
 
 from hub.models import UserProperties
-
-
-def redirect_to_login():
-    return HttpResponseRedirect(reverse_lazy("login"))
-
-
-class AuthPageProtectionMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        if (
-            request.path not in settings.NON_LOGIN_URLS
-            and not request.path.startswith("/accounts/reset/")
-            and not request.path.startswith("/activate/")
-            and not request.path.startswith("/__debug__/")
-            and not request.user.is_authenticated
-        ):
-            return redirect_to_login()
-
-        response = self.get_response(request)
-
-        return response
 
 
 class RecordLastSeenMiddleware:

--- a/hub/mixins.py
+++ b/hub/mixins.py
@@ -22,6 +22,8 @@ class TitleMixin:
 class FilterMixin:
     @cache
     def filters(self):
+        is_non_member = self.request.user.is_anonymous
+
         filters = []
         area_type = self.area_type()
         for param, value in self.request.GET.items():
@@ -39,6 +41,8 @@ class FilterMixin:
 
             try:
                 dataset = DataSet.objects.get(name=name, areas_available=area_type)
+                if is_non_member and not dataset.is_public:
+                    continue
                 filters.append(
                     {
                         "dataset": dataset,
@@ -68,6 +72,8 @@ class FilterMixin:
 
     @cache
     def columns(self, mp_name=False):
+        is_non_member = self.request.user.is_anonymous
+
         columns = []
         col_names = self.request.GET.get("columns", "").split(",")
 
@@ -85,6 +91,8 @@ class FilterMixin:
 
             try:
                 dataset = DataSet.objects.get(name=col, areas_available=area_type)
+                if is_non_member and not dataset.is_public:
+                    continue
                 columns.append(
                     {
                         "dataset": dataset,

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -555,4 +555,18 @@
     </div>
 </div>
 
+{% if not user.is_authenticated %}
+<div class="py-4 py-lg-5 bg-yellow-100 border-top">
+    <div class="container">
+        <aside class="d-flex align-items-center">
+            {% include 'hub/includes/icons/tcc-heart.html' with width="3em" height="3em" classes="me-3 me-lg-4 flex-shrink-0 flex-grow-0" %}
+            <div>
+                <h2 class="h4">Climate Coalition member?</h2>
+                <p class="mb-0"><a href="{% url 'login' %}">Sign in</a> or <a href="{% url 'signup' %}">request an account</a> to access exclusive members-only MRP and local movement data.</p>
+            </div>
+        </aside>
+    </div>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -80,12 +80,14 @@
             <li class="nav-item d-none js-nav-item-featured">
                 <a class="nav-link" href="">Quick facts</a>
             </li>
+          {% if user.is_authenticated %}
             <li class="nav-item d-none js-nav-item-favourites">
                 <a class="nav-link" href="#favourites">
                     {% include 'hub/includes/icons/heart-empty.html' %}
                     Favourites
                 </a>
             </li>
+          {% endif %}
             <li class="nav-item">
                 <a class="nav-link" href="#mp">{% if area_type == "WMC23" %}PPCs{% else %}MP{% endif %}</a>
             </li>
@@ -312,12 +314,14 @@
                 <div class="card dataset-card area-data--sm {% if dataset.is_favourite or dataset.data.is_favourite %}dataset-card--favourite{% endif %} {% if dataset.featured %}area-data--featured{% endif %}">
                 {% endif %}
                     <div class="card-header">
-                      <h3 class="h5">{{ dataset.label }}</h3>
-                      {% include "hub/area/_favourite.html" with dataset=dataset %}
+                        <h3 class="h5">{{ dataset.label }}</h3>
+                      {% if user.is_authenticated %}
+                        {% include "hub/area/_favourite.html" with dataset=dataset %}
+                      {% endif %}
                     </div>
                     <div class="card-body">
                       {% if dataset.data_type == "json" %}
-                      {% include 'hub/area/_json_data.html' with dataset=dataset %}
+                        {% include 'hub/area/_json_data.html' with dataset=dataset %}
                       {% elif dataset.data_type == "text" %}
                         <p class="card-text mb-0 display-6 lh-1 text-primary">{{ dataset.data.value|safe }}</p>
                       {% elif dataset.is_range and dataset.data|length > 0 %}
@@ -383,12 +387,14 @@
                 <div class="card dataset-card area-data--sm {% if dataset.is_favourite or dataset.data.is_favourite %}dataset-card--favourite{% endif %} {% if dataset.featured %} area-data--featured{% endif %}">
                 {% endif %}
                     <div class="card-header">
-                      <h3 class="h5">{{ dataset.label }}</h3>
-                      {% include "hub/area/_favourite.html" with dataset=dataset %}
+                        <h3 class="h5">{{ dataset.label }}</h3>
+                      {% if user.is_authenticated %}
+                        {% include "hub/area/_favourite.html" with dataset=dataset %}
+                      {% endif %}
                     </div>
                     <div class="card-body">
                       {% if dataset.data_type == "json" %}
-                      {% include 'hub/area/_json_data.html' with dataset=dataset %}
+                        {% include 'hub/area/_json_data.html' with dataset=dataset %}
                       {% elif dataset.data_type == "text" %}
                         <p class="card-text mb-0 display-6 lh-1 text-primary">{{ dataset.data.value|safe }}</p>
                       {% elif dataset.data_type == "url" %}
@@ -468,12 +474,14 @@
                 <div class="card dataset-card area-data--sm {% if dataset.is_favourite or dataset.data.is_favourite %}dataset-card--favourite{% endif %} {% if dataset.featured %}area-data--featured{% endif %}">
                 {% endif %}
                     <div class="card-header">
-                      <h3 class="h5">{{ dataset.label }}</h3>
-                      {% include "hub/area/_favourite.html" with dataset=dataset %}
+                        <h3 class="h5">{{ dataset.label }}</h3>
+                      {% if user.is_authenticated %}
+                        {% include "hub/area/_favourite.html" with dataset=dataset %}
+                      {% endif %}
                     </div>
                     <div class="card-body">
                       {% if dataset.data_type == "json" %}
-                      {% include 'hub/area/_json_data.html' with dataset=dataset %}
+                        {% include 'hub/area/_json_data.html' with dataset=dataset %}
                       {% elif dataset.data_type == "percentage" %}
                         <p class="card-text mb-0 display-6 lh-1 text-primary">{{ dataset.data.value|floatformat }}%</p>
                         <p class="card-text mt-2 text-muted">{{dataset.data.average|floatformat }}% national average</p>

--- a/hub/templates/hub/explore.html
+++ b/hub/templates/hub/explore.html
@@ -105,6 +105,16 @@
                 Add data to filter by
             </button>
 
+            {% if not user_is_member %}
+            <div class="mt-4 p-3 bg-white border rounded d-flex align-items-center fs-7">
+                {% include 'hub/includes/icons/tcc-heart.html' with width="2em" height="2em" classes="me-3 flex-shrink-0 flex-grow-0" %}
+                <p class="mb-0">
+                    <strong class="me-2">TCC member?</strong>
+                    <a href="{% url 'login' %}">Sign in</a> or <a href="{% url 'signup' %}">request an account</a> to access exclusive members-only MRP and local movement data.
+                </p>
+            </div>
+            {% endif %}
+
             <div class="tab-content">
                 <div class="tab-pane" :class="{ 'active': mapViewActive }" id="options-map" role="tabpanel" aria-labelledby="tab-map" tabindex="0">
 

--- a/hub/templates/hub/home.html
+++ b/hub/templates/hub/home.html
@@ -6,7 +6,6 @@
     <div class="container mt-n4">
         <h1 class="display-3 mb-3">Local Intelligence Hub</h1>
         <p class="fs-4 mb-4" style="max-width: 30em;">Your starting point for data about local MPs, constituencies, public opinion and the climate and nature movement.</p>
-      {% if user.is_authenticated %}
         <label class="form-label" for="search">Search by constituency name, MP name, or postcode</label>
         <form class="row mt-2 mb-2 js-homepage-search" style="max-width: 30rem;" action="{% url 'area_search' %}">
             <div class="col">
@@ -23,10 +22,6 @@
             {% include 'hub/includes/icons/geolocate.html' with classes="me-2" %}
             Use my current location
         </a>
-      {% else %}
-        <p class="fs-5">Now in <strong>early access preview</strong> for Climate Coalition members.</p>
-        <a href="{% url 'explore' %}" class="btn btn-lg btn-primary">Member sign in</a>
-      {% endif %}
     </div>
 </div>
 
@@ -38,11 +33,7 @@
                 <h2 class="mb-4 h1">Explore data across the&nbsp;UK</h2>
                 <p class="mb-4 fs-5" style="max-width: 28em;">Use data from The Climate Coalition, its member organisations, and the wider sector, to narrow down your focus to the areas and constituencies that matter to you.</p>
                 <p class="mb-4 fs-5" style="max-width: 28em;">Use the interactive map to discover data about your area, then export as a spreadsheet for further analysis.</p>
-              {% if user.is_authenticated %}
                 <a href="{% url 'explore' %}" class="btn btn-lg btn-primary">Start exploring</a>
-              {% else %}
-                <a href="{% url 'explore' %}" class="btn btn-lg btn-primary">Member sign in</a>
-              {% endif %}
             </div>
 
             <a class="col-lg-5 offset-lg-1 pt-5 pb-6 pb-lg-5 d-flex flex-column align-items-center justify-content-center" href="{% url 'explore' %}">

--- a/hub/templates/hub/includes/header.html
+++ b/hub/templates/hub/includes/header.html
@@ -8,9 +8,9 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav ms-auto flex-wrap justify-content-end">
-              {% if user.is_authenticated %}
                 {% include 'hub/includes/nav-item.html' with name='home' label='Search' %}
                 {% include 'hub/includes/nav-item.html' with name='explore' label='Map' %}
+              {% if user.is_authenticated %}
                 {% include 'hub/includes/nav-item.html' with name='my_account' label='Account' %}
               {% else %}
                 {% include 'hub/includes/nav-item.html' with name='login' label='Sign in' %}

--- a/hub/views/explore.py
+++ b/hub/views/explore.py
@@ -15,6 +15,13 @@ class ExploreView(TitleMixin, TemplateView):
     page_title = "Explore"
     template_name = "hub/explore.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context["user_is_member"] = not self.request.user.is_anonymous
+
+        return context
+
 
 class ExploreDatasetsJSON(TemplateView):
     def render_to_response(self, context, **response_kwargs):

--- a/local_intelligence_hub/settings.py
+++ b/local_intelligence_hub/settings.py
@@ -88,7 +88,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "hub.middleware.AuthPageProtectionMiddleware",
     "hub.middleware.RecordLastSeenMiddleware",
 ]
 


### PR DESCRIPTION
This does three things:

*  hides non public datasets from unauthenticated users
* updates the area page layout a bit to tidy up the resulting empty boxes etc for unauthenticated users
* turns off the mandatory login for all pages

Fixes https://github.com/mysociety/local-intelligence-hub/issues/280

This replaces #312 which was too out of sync with the area page updates.