### PR TITLE
update existing FoE supporters import for new data

### DIFF
--- a/hub/management/commands/import_foe_supporters.py
+++ b/hub/management/commands/import_foe_supporters.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 import pandas as pd
 
-from hub.models import AreaData, DataSet
+from hub.models import DataSet
 
 from .base_importers import BaseImportFromDataFrameCommand
 
@@ -10,23 +10,28 @@ from .base_importers import BaseImportFromDataFrameCommand
 class Command(BaseImportFromDataFrameCommand):
     help = "Import data about number of FOE supporters per constituency"
 
-    data_file = settings.BASE_DIR / "data" / "foe_supporters.csv"
+    data_file = settings.BASE_DIR / "data" / "foe_supporters_and_activists_wmc23.csv"
     cons_row = "constituency"
-    message = "Importing FOE supporters data"
+    message = "Importing FOE supporters and activists data"
     uses_gss = False
+    area_type = "WMC23"
+    do_not_convert = True
 
     defaults = {
         "data_type": "integer",
         "category": "movement",
         "subcategory": "supporters_and_activists",
-        "release_date": "November 2022",
+        "release_date": "January 2024",
         "source_label": "Data from Friends of the Earth.",
         "source": "https://friendsoftheearth.uk/",
         "source_type": "google sheet",
         "table": "areadata",
         "default_value": 10,
         "data_url": "",
+        "exclude_countries": ["Northern Ireland", "Scotland"],
         "comparators": DataSet.numerical_comparators(),
+        "is_filterable": True,
+        "is_public": True,
         "unit_type": "raw",
         "unit_distribution": "people_in_area",
     }
@@ -35,14 +40,16 @@ class Command(BaseImportFromDataFrameCommand):
         "constituency_foe_activists_count": {
             "defaults": {
                 **defaults,
-                "description": "Number of Friends of the Earth activists per constituency.",
+                "label": "Friends of the Earth activists",
+                "description": "Activists have taken at least one online action for Friends of the Earth in the last 12 months.",
             },
             "col": "activists",
         },
         "constituency_foe_supporters_count": {
             "defaults": {
                 **defaults,
-                "description": "Number of Friends of the Earth supporters per constituency.",
+                "label": "Friends of the Earth financial supporters",
+                "description": "Financial supporters have donated to Friends of the Earth in the last 12 months.",
             },
             "col": "supporters",
         },
@@ -53,12 +60,10 @@ class Command(BaseImportFromDataFrameCommand):
         df = df.dropna(axis="columns", how="all")
         df = df.dropna(axis="rows", how="any")
         df.columns = ["constituency", "supporters", "activists"]
+        df.constituency = df.constituency.str.replace("Ynys Mon", "Ynys Môn")
+        df.constituency = df.constituency.str.replace(
+            "Montgomeryshire and Glyndwr", "Montgomeryshire and Glyndŵr"
+        )
         df = df.astype({"supporters": int, "activists": int})
 
         return df
-
-    def get_label(self, defaults):
-        return f"Number of Friends of the Earth {defaults['col']}"
-
-    def delete_data(self):
-        AreaData.objects.filter(data_type__in=self.data_types.values()).delete()


### PR DESCRIPTION
This updates the existing script to handle the new data with new labels etc.

To import download the relevant tab as a csv and save in data as `foe_supporters_and_activists_wmc23.csv`

Fixes #380 