### PR TITLE
Reinstate members-only warning on non-public datasets

### DIFF
--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -357,6 +357,9 @@
                         {% if dataset.release_date %}
                           Updated {{ dataset.release_date }}.
                         {% endif %}
+                        {% if not dataset.is_public %}
+                          <strong class="text-danger">Not to be publicly shared.</strong>
+                        {% endif %}
                      </p>
 
                     </div>
@@ -441,6 +444,9 @@
                         {% endif %}
                         {% if dataset.release_date %}
                           Updated {{ dataset.release_date }}.
+                        {% endif %}
+                        {% if not dataset.is_public %}
+                          <strong class="text-danger">Not to be publicly shared.</strong>
                         {% endif %}
                       </p>
 
@@ -544,6 +550,9 @@
                         {% endif %}
                         {% if dataset.release_date %}
                           Updated {{ dataset.release_date }}.
+                        {% endif %}
+                        {% if not dataset.is_public %}
+                          <strong class="text-danger">Not to be publicly shared.</strong>
                         {% endif %}
                       </p>
 

--- a/hub/views/area.py
+++ b/hub/views/area.py
@@ -95,6 +95,7 @@ class BaseAreaView(TitleMixin, DetailView):
             "release_date": data_set.release_date,
             "auto_conversion_disclaimer": auto_converted.get(data_set.id, None),
             "is_favourite": favs.get(data_set.id, False),
+            "is_public": data_set.is_public,
         }
         if data_set.is_range:
             data["is_range"] = True


### PR DESCRIPTION
Part of #383 snagging.

Re-introduces the orange “Not to be publicly shared” warning on the area page – but this time, we’re able to use the `is_public` flag on datasets, rather than hard-coding the warning to only apply to the HOPE not hate MRP datasets.

<img width="444" alt="Screenshot 2024-01-19 at 17 11 03" src="https://github.com/mysociety/local-intelligence-hub/assets/739624/17ae29c9-2f86-4dc0-9c60-651739bd3d66">
