### PR TITLE
Remove pointless descriptions from MRP datasets

### DIFF
--- a/hub/management/commands/import_cost_of_living_mrp_data.py
+++ b/hub/management/commands/import_cost_of_living_mrp_data.py
@@ -45,18 +45,6 @@ class Command(BaseImportFromDataFrameCommand):
         "mental_health_cost_of_living": "Mental health has been impacted by the cost of living crisis",
     }
 
-    descriptions = {
-        "not_able_to_afford_mortgage_rent": "Estimated percentage of constituents worried about not being able to afford their mortgage or rent in the next year.",
-        "not_able_to_pay_energy_bills": "Estimated percentage of constituents worried about not being able to pay their energy bills in the next year.",
-        "worried_foodbank": "Estimated percentage of constituents worried about having to use a foodbank in the next year.",
-        "conservatives_dont_understand_impact": "Estimated percentage of constituents who think that Rishi Sunak and the Conservative Government do not understand the impact the cost of living crisis is having on people.",
-        "missed_bill_payment": "Estimated percentage of constituents that have missed a bill payment in the last six months.",
-        "missed_rent_payment": "Estimated percentage of constituents that have missed a rent payment in the last six months.",
-        "missed_credit_payment": "Estimated percentage of constituents that have missed a credit payment in the last six months.",
-        "cant_afford_heating": "Estimated percentage of constituents that have not been able to afford to turn the heating on at home when they have felt cold in the past month.",
-        "mental_health_cost_of_living": "Estimated percentage of constituents whose mental health has been impacted by the cost of living crisis.",
-    }
-
     def add_data_sets(self, df):
         for col in df.columns:
             if col != "gss_code":
@@ -65,7 +53,6 @@ class Command(BaseImportFromDataFrameCommand):
                     "col": col,
                 }
                 self.data_sets[col]["defaults"]["label"] = self.labels[col]
-                self.data_sets[col]["defaults"]["description"] = self.descriptions[col]
 
         super().add_data_sets()
 

--- a/hub/management/commands/import_onward_polling_data.py
+++ b/hub/management/commands/import_onward_polling_data.py
@@ -42,31 +42,19 @@ class Command(BaseImportFromDataFrameCommand):
 
     data_sets = {
         "constituency_nz_support": {
-            "defaults": {
-                **defaults,
-                "description": "Estimated percentage of constituents who support net zero.",
-            },
+            "defaults": defaults,
             "col": "support net zero",
         },
         "constituency_nz_neutral": {
-            "defaults": {
-                **defaults,
-                "description": "Estimated percentage of constituents who neither support nor oppose net zero.",
-            },
+            "defaults": defaults,
             "col": "neither support nor oppose net zero",
         },
         "constituency_nz_oppose": {
-            "defaults": {
-                **defaults,
-                "description": "Estimated percentage of constituents who oppose net zero.",
-            },
+            "defaults": defaults,
             "col": "oppose net zero",
         },
         "constituency_cc_high": {
-            "defaults": {
-                **defaults,
-                "description": "Estimated percentage of constituents who consider climate change a high priority.",
-            },
+            "defaults": defaults,
             "col": "consider climate change a high priority",
         },
     }

--- a/hub/management/commands/import_renewables_polling_data.py
+++ b/hub/management/commands/import_renewables_polling_data.py
@@ -23,22 +23,6 @@ SUBCATEGORIES_DICT = {
     "believe-block-onshore-wind": "government_action",
 }
 
-DESCRIPTIONS = {
-    "would-change-party": "Estimated percentage of constituents that are considering voting for a different party in the next General Election to the one they voted for in 2019.",
-    "less-favourable-conservative-weaken-climate": "Estimated percentage of constituents that would be less favourable towards the Conservative Party if they chose to weaken climate policies.",
-    "prefer-conservative-leader-invest-renewables": "Estimated percentage of constituents that would prefer the next leader of the Conservative Party to invest in renewable energy.",
-    "support-offshore-wind": "Estimated percentage of constituents that support offshore wind as energy generation.",
-    "support-onshore-wind": "Estimated percentage of constituents that support onshore wind as energy generation.",
-    "support-solar": "Estimated percentage of constituents that support solar power as energy generation.",
-    "support-tidal": "Estimated percentage of constituents that support tidal energy as energy generation.",
-    "support-wave": "Estimated percentage of constituents that support wave energy as energy generation.",
-    "support-nuclear": "Estimated percentage of constituents that support nuclear energy as energy generation.",
-    "support-local-renewable": "Estimated percentage of constituents who support renewable energy projects in their local area.",
-    "believe-gov-renewable-invest-increase": "Estimated percentage of constituents that believe the Govt has increased investment in renewables over the past 5 years.",
-    "believe-gov-renewable-should-invest": "Estimated percentage of constituents that believe that the Govt should use wind and solar farms to reduce energy bills.",
-    "believe-block-onshore-wind": "Estimated percentage of constituents that believe that the Govt should continue the block on onshore wind development.",
-}
-
 
 class Command(BaseImportFromDataFrameCommand):
     help = "Import polling data about support for renewables"
@@ -97,10 +81,8 @@ class Command(BaseImportFromDataFrameCommand):
                 continue
 
             label = self.make_label_from_question(self.column_map[column])
-            description = DESCRIPTIONS[column]
             defaults = {
                 "label": label,
-                "description": description,
                 "data_type": "percent",
                 "category": "opinion",
                 "subcategory": SUBCATEGORIES_DICT[column],
@@ -130,7 +112,6 @@ class Command(BaseImportFromDataFrameCommand):
                 defaults={
                     "data_type": "percent",
                     "label": label,
-                    "description": description,
                 },
             )
 


### PR DESCRIPTION
Part of dataset cleanup in #364. (I thought about making this commit as part of @alexander-griffen’s clean up of datasets in #396, but figured separate is probably easier to review.)

The new dataset modal in #404 made it clear how repetitious most of the MRP datasets’ descriptions were – simply rewording the dataset label with "estimated percentage of…" at the start.

Hinting that the MRP figures are indeed _estimates_ is probably a nice thing to do, but not if it means as much clutter as this. Let’s revisit again in the near future, especially as we start to get non-technical users on the platform, who might not know what MRP polling even is.

@struan I’m not sure whether this will _remove_ the existing descriptions when the import scripts are next run, or whether we’ll need to do that by hand?