### PR TITLE
only search for MPs

### DIFF
--- a/hub/views/area.py
+++ b/hub/views/area.py
@@ -356,7 +356,7 @@ class AreaSearchView(TemplateView):
             areas_raw = Area.objects.filter(
                 name__icontains=search, area_type__code="WMC"
             )
-            people_raw = Person.objects.filter(name__icontains=search)
+            people_raw = Person.objects.filter(person_type="MP", name__icontains=search)
 
             areas = list(areas_raw)
             for person in people_raw:


### PR DESCRIPTION
Partly as this avoids issues with matching multiple constituencies and also to avoid multiple person objects being returned for an area.

Fixes #410