### PR TITLE
Update VSCode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,16 @@
     "[python]": {
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
-        }
+            "source.organizeImports": "explicit"
+        },
+        "editor.defaultFormatter": "ms-python.black-formatter"
     },
-    "python.formatting.provider": "black",
-    "python.formatting.blackPath": "${workspaceFolder}/script/black",
+    "black-formatter.path": ["${workspaceFolder}", "script", "black"],
+    "flake8.path": ["${workspaceFolder}", "script", "flake8"],
+    "flake8.args": [
+        "--exclude \".venv\" ."
+    ],
+
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,
@@ -24,11 +29,5 @@
         "**/templates/**/*.html": "django-html",
         "**/templates/**/*": "django-txt",
         "**/requirements{/**,*}.{txt,in}": "pip-requirements"
-    },
-    "python.linting.flake8Enabled": true,
-    "python.linting.flake8Path": "${workspaceFolder}/script/flake8",
-    "python.linting.flake8Args": [
-        "--exclude \".venv\" ."
-    ],
-    "python.linting.enabled": true
+    }
 }


### PR DESCRIPTION
- `"source.organizeImports": true` has been deprecated since 1.85, with versions since then automatically converting it to `"explicit"` instead. So best to just change it now.
- Python formatting was moved out of core VSCode and into extensions some time in 2023. Replace `python.formatting` settings with the analogous `black-formatter` and `flake8` extension settings.
- Move all the Python/formatting related settings near each other.