### PR TITLE
WIP: Remove unapplicable datatypes from filter and shader dropdowns

### DIFF
--- a/hub/static/js/explore.esm.js
+++ b/hub/static/js/explore.esm.js
@@ -586,6 +586,9 @@ const app = createApp({
         default:
           return true
       }
+    },
+    getDataTypesForCurrentArea(dataset) {
+        return dataset.types.filter(t => t.area_type === this.area_type || t.area_type === null)
     }
   }
 })

--- a/hub/templates/hub/explore.html
+++ b/hub/templates/hub/explore.html
@@ -47,10 +47,10 @@
                         </div>
                         <div :class="{ 'filter__body': true, 'filter__body--expanded': filter.is_in }">
                             <select v-if="filter.is_range" v-model="filter.selectedType" class="form-select form-select-sm flex-grow-0 flex-shrink-1">
-                            <option v-for="ds_type in filter.types" :value="ds_type.name">${ ds_type.title }</option>
+                                <option v-for="ds_type in getDataTypesForCurrentArea(filter)" :value="ds_type.name">${ ds_type.title }</option>
                             </select>
                             <select v-model="filter.selectedComparator" class="form-select form-select-sm flex-grow-0 flex-shrink-1">
-                            <option v-for="(title, comparator) in filter.comparators" :value="comparator">${ title }</option>
+                                <option v-for="(title, comparator) in filter.comparators" :value="comparator">${ title }</option>
                             </select>
                             <select v-if="filter.options" v-model="filter.selectedValue" :multiple="filter.is_in" class="form-select form-select-sm flex-grow-1 flex-shrink-1">
                                 <option v-for="option in filter.options" :value="option">${ option }</option>
@@ -134,7 +134,7 @@
                             </ul>
                             <div :class="{ 'filter__body': true, 'filter__body--expanded': true }">
                                 <select v-if="shader.is_range" v-model="shader.selectedType" class="form-select form-select-sm flex-grow-0 flex-shrink-1">
-                                <option v-for="ds_type in shader.types" :value="ds_type.name">${ ds_type.title }</option>
+                                    <option v-for="ds_type in getDataTypesForCurrentArea(shader)" :value="ds_type.name">${ ds_type.title }</option>
                                 </select>
                             </div>
                             <div v-if="key" class="mt-3">

--- a/hub/templates/hub/explore.html
+++ b/hub/templates/hub/explore.html
@@ -121,9 +121,9 @@
                     <h2 class="h5 mt-4 mt-lg-5 mb-3 mb-lg-4 text-primary">Step 3: Shade constituencies (optional)</h2>
 
                     <div ref="shaderContainer" hidden>
-                        <div v-if="shader" class="border p-3 rounded" :class="{ 'bg-gray-100': shader.areas_available.includes(area_type), 'bg-red-100': !shader.areas_available.includes(area_type) }">
-                            <div class="d-flex">
-                                <h3 class="h6 mb-0 me-auto">${ shader.title }</h3>
+                        <div v-if="shader" class="filter mb-0" :class="{ 'bg-red-100': !shader.areas_available.includes(area_type) }">
+                            <div class="filter__header">
+                                <h3 class="h6">${ shader.title }</h3>
                                 <button @click="removeShader(shader.name)" type="button" class="btn-close p-0" aria-label="Remove shader"></button>
                             </div>
                             <ul v-if="legend" class="mt-3 mb-0 list-unstyled fs-7 lh-1 text-muted">

--- a/hub/views/explore.py
+++ b/hub/views/explore.py
@@ -114,8 +114,14 @@ class ExploreDatasetsJSON(TemplateView):
                 ds = {**ds, **type_map[d.name]}
             if d.is_range:
                 ds["types"] = [
-                    {"name": dt.name, "title": dt.label}
-                    for dt in DataType.objects.filter(data_set=d)
+                    {
+                        "name": dt.name,
+                        "title": dt.label,
+                        "area_type": dt.area_type.code if dt.area_type else None,
+                    }
+                    for dt in DataType.objects.filter(data_set=d).select_related(
+                        "area_type"
+                    )
                 ]
             datasets.append(ds)
 


### PR DESCRIPTION
Fixes #442. Fixes #441.

I’m having a bit of an issue testing this out locally, as it seems all of my local `is_range` datasets aren’t showing up in the dataset picker modal for some reason… 🤔 But I _think_ this should work.