### PR TITLE
Improve handling of lower case area names and area codes

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -412,6 +412,8 @@ class DataSet(TypeMixin, ShaderMixin, models.Model):
 
 
 class AreaType(models.Model):
+    VALID_AREA_TYPES = ["WMC", "WMC23"]
+
     AREA_TYPES = [("westminster_constituency", "Westminster Constituency")]
     name = models.CharField(max_length=50, unique=True)
     code = models.CharField(max_length=10, unique=True)

--- a/hub/tests/test_views.py
+++ b/hub/tests/test_views.py
@@ -197,6 +197,23 @@ class TestAreaPage(TestCase):
         self.u = User.objects.create(username="user@example.com")
         self.client.force_login(self.u)
 
+    def test_area_page_bad_area(self):
+        url = reverse("area", args=("WMC", "East Borsetshire"))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_area_page_bad_area_code(self):
+        url = reverse("area", args=("WMX", "South Borsetshire"))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_area_page_lower_case_area_code(self):
+        url = reverse("area", args=("wmc", "South Borsetshire"))
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.headers["Location"], "/area/WMC/South%20Borsetshire")
+
     def test_area_page_logged_in(self):
         DataSet.objects.update(featured=True)
         url = reverse("area", args=("WMC", "South Borsetshire"))

--- a/hub/tests/test_views.py
+++ b/hub/tests/test_views.py
@@ -214,6 +214,13 @@ class TestAreaPage(TestCase):
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response.headers["Location"], "/area/WMC/South%20Borsetshire")
 
+    def test_area_page_lower_case_area_name(self):
+        url = reverse("area", args=("wmc", "south borsetshire"))
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.headers["Location"], "/area/WMC/South%20Borsetshire")
+
     def test_area_page_logged_in(self):
         DataSet.objects.update(featured=True)
         url = reverse("area", args=("WMC", "South Borsetshire"))


### PR DESCRIPTION
If someone uses lower case area codes or area names in the area url then redirect then to the canonical url instead of 404ing