### PR TITLE
improve MP import script

### DIFF
--- a/hub/management/commands/import_mps.py
+++ b/hub/management/commands/import_mps.py
@@ -84,6 +84,12 @@ class Command(BaseCommand):
         id_df = id_df.drop(columns=["scheme"])
         id_df = id_df.rename(columns={"identifier": "parlid"})
 
+        # TODO: Remove this temporary workaround, once February 2024 byelection MPs are added upstream.
+        patch_df = pd.DataFrame(
+            [{"twfyid": 26287, "parlid": "5010"}, {"twfyid": 26288, "parlid": "5011"}]
+        )
+        id_df = pd.concat([id_df, patch_df])
+
         return id_df
 
     def get_area_map(self):


### PR DESCRIPTION
This uses the TWFY MP CSV as the base information rather than wikidata as it doesn't seem to keep up to date, and also this way the data is in our control which is probably good.

It does mean we need to get three sets of data to enable all the same information but again, the MP list and the parliament ID, which is required for election results among other things, is now using our data which is probably better.