### PR TITLE
call the Green Party the Green Party everywhere

### DIFF
--- a/hub/management/commands/import_2024_ppcs.py
+++ b/hub/management/commands/import_2024_ppcs.py
@@ -12,7 +12,7 @@ party_shades = {
     "Alliance Party of Northern Ireland": "#F6CB2F",
     "Conservative Party": "#0087DC",
     "Democratic Unionist Party": "#D46A4C",
-    "Green Party of England and Wales": "#6AB023",
+    "Green Party": "#6AB023",
     "Labour Co-operative": "#E4003B",
     "Labour Party": "#E4003B",
     "Liberal Democrats": "#FAA61A",

--- a/hub/management/commands/import_last_election_data.py
+++ b/hub/management/commands/import_last_election_data.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
         "dup": "Democratic Unionist Party",
         "uup": "Ulster Unionist Party",
         "con": "Conservative Party",
-        "green": "Green Party of England and Wales",
+        "green": "Green Party",
         "pbpa": "People Before Profit Alliance",
     }
 
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         {"title": "Alliance Party of Northern Ireland", "shader": "#F6CB2F"},
         {"title": "Conservative Party", "shader": "#0087DC"},
         {"title": "Democratic Unionist Party", "shader": "#D46A4C"},
-        {"title": "Green Party of England and Wales", "shader": "#6AB023"},
+        {"title": "Green Party", "shader": "#6AB023"},
         {"title": "Labour Co-operative", "shader": "#E4003B"},
         {"title": "Labour Party", "shader": "#E4003B"},
         {"title": "Liberal Democrats", "shader": "#FAA61A"},

--- a/hub/management/commands/import_mps.py
+++ b/hub/management/commands/import_mps.py
@@ -21,7 +21,7 @@ party_shades = {
     "Alliance Party of Northern Ireland": "#F6CB2F",
     "Conservative Party": "#0087DC",
     "Democratic Unionist Party": "#D46A4C",
-    "Green Party of England and Wales": "#6AB023",
+    "Green Party": "#6AB023",
     "Labour Co-operative": "#E4003B",
     "Labour Party": "#E4003B",
     "Liberal Democrats": "#FAA61A",

--- a/hub/management/commands/import_mps_appg_data.py
+++ b/hub/management/commands/import_mps_appg_data.py
@@ -14,7 +14,7 @@ party_lookup = {
     "Labour (Co-op)": "Labour Co-operative",
     "Independent": "independent politician",
     "Alliance": "Alliance Party of Northern Ireland",
-    "Green Party": "Green Party of England and Wales",
+    "Green Party": "Green Party",
     "Speaker": "Speaker of the House of Commons",
     "Social Democratic & Labour Party": "Social Democratic and Labour Party",
 }


### PR DESCRIPTION
Standardise on this rather than use the correct names for the Scottish and England/Wales parties. It's not strictly correct but makes it easier for things like "show all constituencies with a green party candidate".

Fixes #473