### PR TITLE
DATASET: Wildlife trusts regions

### DIFF
--- a/hub/management/commands/base_importers.py
+++ b/hub/management/commands/base_importers.py
@@ -302,12 +302,14 @@ class BaseConstituencyGroupListImportCommand(BaseAreaImportCommand):
                 area=area,
                 json=json,
             )
-
-            count_data, created = AreaData.objects.update_or_create(
-                data_type=self.data_types[self.count_data_type],
-                area=area,
-                data=len(data),
-            )
+            try:
+                count_data, created = AreaData.objects.update_or_create(
+                    data_type=self.data_types[self.count_data_type],
+                    area=area,
+                    data=len(data),
+                )
+            except AttributeError:
+                pass
 
     def handle(self, quiet=False, *args, **kwargs):
         self._quiet = quiet

--- a/hub/management/commands/import_wildlife_trusts_regions.py
+++ b/hub/management/commands/import_wildlife_trusts_regions.py
@@ -1,0 +1,53 @@
+from django.conf import settings
+
+import pandas as pd
+
+from hub.models import DataSet
+
+from .base_importers import BaseConstituencyGroupListImportCommand
+
+
+class Command(BaseConstituencyGroupListImportCommand):
+    help = "Import Wildlife trust reserves"
+
+    data_file = (
+        settings.BASE_DIR / "data" / "wildlife_trust_regions_in_constituencies.csv"
+    )
+    cons_row = "PCON19NM"
+    uses_gss = False
+    message = "Importing constituency Wildlife Trust regions data"
+
+    data_sets = {
+        "wildlife_trusts_regions": {
+            "defaults": {
+                "label": "Wildlife Trust Regions",
+                "description": "The Wildlife Trust Region(s) that a constituency falls under.",
+                "data_type": "json",
+                "category": "place",
+                "subcategory": "groups",
+                "source_label": "Data from The Widlife Trusts",
+                "source": "https://www.wildlifetrusts.org/",
+                "source_type": "csv",
+                "table": "areadata",
+                "is_filterable": False,
+                "is_shadable": False,
+                "comparators": DataSet.in_comparators(),
+            },
+            "col": "Trust",
+        }
+    }
+    group_data_type = "wildlife_trusts_regions"
+
+    def get_df(self):
+        return pd.read_csv(self.data_file, usecols=["Trust", "PCON19NM"]).rename(
+            columns={"PCON19NM": "constituency"}
+        )
+
+    def get_group_json(self, row):
+        return row[["Trust"]].dropna().rename({"Trust": "group_name"}).to_dict()
+
+    def update_averages(self):
+        pass
+
+    def update_max_min(self):
+        pass


### PR DESCRIPTION
Fixes #317 

NOTE: The dataset csv can be found in the shared drive.

Additionally, the following script was used to produce it: 
```
import geopandas as gpd

wildlife_trust_regions = gpd.read_file(
    "Wildlife_Trust_Regional_Boundaries_-_Open_Data.zip"
)
constituencies = gpd.read_file(
    "WPC_Dec_2019_Boundaries_UK_BFC_V2_2022_-7467643007870890518.zip"
)


constituencies = constituencies.to_crs("EPSG:4326")
combined = wildlife_trust_regions.overlay(constituencies, how="intersection")

combined["area"] = combined.geometry.area
combined = combined.query("area >= 0.00125")

combined[["Trust", "PCON19NM"]].to_csv("wildlife_trust_regions_in_constituencies.csv")
```

The number used - 0.00125 - was callibrated by incrementing and de-incrementing it until the dataset covered every constituency, but didn't overlap egregiously.