### PR TITLE
Wrap text inside Explore map tooltips onto multiple lines

### DIFF
--- a/hub/static/css/_explore.scss
+++ b/hub/static/css/_explore.scss
@@ -147,11 +147,13 @@ $osm-sea-blue: rgb(168, 212, 243);
 
 .leaflet-tooltip {
     font-family: var(--bs-body-font-family);
-    font-size: var(--bs-body-font-size);
+    font-size: $font-size-sm;
     line-height: 1.3;
     padding: 0.4rem 0.5rem;
+    white-space: normal;
 
     .table {
+        width: 20em;
         margin: 0.25rem 0 0 0;
 
         tr:last-child > * {
@@ -166,6 +168,7 @@ $osm-sea-blue: rgb(168, 212, 243);
         tr > :last-child {
             text-align: right;
             padding-right: 0;
+            white-space: nowrap;
         }
     }
 }


### PR DESCRIPTION
I don’t like the hard-coded `20em` here, but couldn’t think of a better way to do it.