### PR TITLE
Warn if a group name is blank in base importer

### DIFF
--- a/hub/management/commands/base_importers.py
+++ b/hub/management/commands/base_importers.py
@@ -295,7 +295,11 @@ class BaseConstituencyGroupListImportCommand(BaseAreaImportCommand):
 
             json = []
             for index, row in data.iterrows():
-                json.append(self.get_group_json(row))
+                group = self.get_group_json(row)
+                if group.get("group_name", None) is None:
+                    print(f"missing group name for {area.name}")
+                    continue
+                json.append(group)
 
             json_data, created = AreaData.objects.update_or_create(
                 data_type=self.data_types[self.group_data_type],
@@ -306,7 +310,7 @@ class BaseConstituencyGroupListImportCommand(BaseAreaImportCommand):
             count_data, created = AreaData.objects.update_or_create(
                 data_type=self.data_types[self.count_data_type],
                 area=area,
-                data=len(data),
+                data=len(json),
             )
 
     def handle(self, quiet=False, *args, **kwargs):

--- a/hub/management/commands/import_foe_groups.py
+++ b/hub/management/commands/import_foe_groups.py
@@ -28,7 +28,7 @@ class Command(BaseConstituencyGroupListImportCommand):
         "default_value": {},
         "data_url": "",
         "exclude_countries": ["Scotland"],
-        "is_filterable": True,
+        "is_filterable": False,
         "is_shadable": False,
         "is_public": True,
         "comparators": DataSet.string_comparators(),


### PR DESCRIPTION
The base group name importer accepted blank group names which resulted in empty "tags" in the UI. This checks if the name returned has a value and warns if not.

There's also a fix in here setting the FoE local action groups data set to be non filterable as it's JSON.

Fixes #495