### PR TITLE
Add a fake dataset for the constituency URL

### DIFF
--- a/hub/mixins.py
+++ b/hub/mixins.py
@@ -80,12 +80,12 @@ class FilterMixin:
         if mp_name:
             col_names.append("mp_name")
 
-        col_label_map = {"mp_name": "MP Name", "gss": "GSS"}
+        col_label_map = {"mp_name": "MP Name", "gss": "GSS", "url": "URL"}
 
         area_type = self.area_type()
 
         for col in col_names:
-            if col in ["mp_name", "gss"]:
+            if col in ["mp_name", "gss", "url"]:
                 columns.append({"name": col, "label": col_label_map[col]})
                 continue
 
@@ -212,6 +212,12 @@ class FilterMixin:
             elif col["name"] == "gss":
                 for row in self.query():
                     area_data[row.name]["GSS"].append(row.gss)
+                continue
+            elif col["name"] == "url":
+                for row in self.query():
+                    area_data[row.name]["URL"].append(
+                        f"{self.request.build_absolute_uri(row.get_absolute_url())}"
+                    )
                 continue
 
             dataset = col["dataset"]

--- a/hub/tests/test_views.py
+++ b/hub/tests/test_views.py
@@ -51,13 +51,13 @@ class TestExploreDatasetsPage(TestCase):
         self.assertEqual(response.status_code, 200)
 
         datasets = response.json()
-        self.assertEqual(11, len(datasets))
+        self.assertEqual(12, len(datasets))
 
         self.client.logout()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         datasets = response.json()
-        self.assertEqual(4, len(datasets))
+        self.assertEqual(5, len(datasets))
 
     def test_explore_view_with_many_to_one(self):
         url = f"{reverse('explore_csv')}?mp_appg_membership__exact=MadeUpAPPG"

--- a/hub/views/explore.py
+++ b/hub/views/explore.py
@@ -155,6 +155,22 @@ class ExploreDatasetsJSON(TemplateView):
             }
         )
 
+        datasets.append(
+            {
+                "scope": "public",
+                "is_featured": False,
+                "is_favourite": False,
+                "is_filterable": False,
+                "is_shadable": False,
+                "category": "place",
+                "name": "url",
+                "title": "Constituency URL",
+                "description": "A link to this constituency on the Local Intelligence Hub.",
+                "source_label": "Data from mySociety.",
+                "areas_available": ["WMC", "WMC23"],
+            }
+        )
+
         return JsonResponse(list(datasets), safe=False)
 
 


### PR DESCRIPTION
Handy when you’re downloading constituency data as a CSV, and want to be able to quickly link back to the Area’s webpage.