### PR TITLE
Import and display action scorecards scores for local councils

### DIFF
--- a/hub/management/commands/import_council_scorecards_score.py
+++ b/hub/management/commands/import_council_scorecards_score.py
@@ -1,0 +1,167 @@
+from django.conf import settings
+
+import pandas as pd
+from tqdm import tqdm
+
+from hub.import_utils import filter_authority_type
+from hub.models import DataSet, DataType
+
+from .base_importers import BaseImportFromDataFrameCommand, MultipleAreaTypesMixin
+
+declare_map = {
+    "Y": "Yes",
+    "N": "No",
+}
+
+
+class Command(MultipleAreaTypesMixin, BaseImportFromDataFrameCommand):
+    cons_row = "gss_code"
+    message = "Importing council scorecards data"
+    uses_gss = True
+    do_not_convert = True
+
+    data_file = settings.BASE_DIR / "data" / "2023_scorecards_data.csv"
+
+    area_types = ["STC", "DIS"]
+
+    defaults = {
+        "label": "Council Climate Action Scorecard",
+        "description": "",
+        "data_type": "percent",
+        "category": "place",
+        "release_date": "2023",
+        "source_label": "Data from Climate Emergency UK.",
+        "source": "https://councilclimatescorecards.uk/",
+        "source_type": "csv",
+        "table": "areadata",
+        "data_url": "",
+        "comparators": DataSet.numerical_comparators(),
+        "is_filterable": True,
+        "is_shadable": True,
+        "is_public": True,
+        "unit_type": "raw",
+        "unit_distribution": "physical_area",
+    }
+
+    data_sets = {
+        "council_action_scorecard_total": {
+            "defaults": defaults,
+            "col": "weighted_total",
+        },
+        "council_action_scorecard_bh": {
+            "defaults": {
+                **defaults,
+                "label": "Buildings & Heating",
+            },
+            "col": "Buildings & Heating",
+        },
+        "council_action_scorecard_transport": {
+            "defaults": {
+                **defaults,
+                "label": "Transport",
+            },
+            "col": "Transport",
+        },
+        "council_action_scorecard_planning": {
+            "defaults": {
+                **defaults,
+                "label": "Planning & Land Use",
+            },
+            "col": "Planning & Land Use",
+        },
+        "council_action_scorecard_governance": {
+            "defaults": {
+                **defaults,
+                "label": "Goverance & Finance",
+            },
+            "col": "Governance & Finance",
+        },
+        "council_action_scorecard_biodiversity": {
+            "defaults": {
+                **defaults,
+                "label": "Biodiversity",
+            },
+            "col": "Biodiversity",
+        },
+        "council_action_scorecard_collaboration": {
+            "defaults": {
+                **defaults,
+                "label": "Collaboration & Engagement",
+            },
+            "col": "Collaboration & Engagement",
+        },
+        "council_action_scorecard_waste": {
+            "defaults": {
+                **defaults,
+                "label": "Waste Reduction & Food",
+            },
+            "col": "Waste Reduction & Food",
+        },
+    }
+
+    # do not want to calculate averages as the comparisons are only relevant
+    # to councils of the same type
+    def update_averages(self):
+        pass
+
+    def add_data_sets(self, df):
+        if not self._quiet:
+            self.stdout.write("Creating dataset + types")
+
+        total_data_set, created = DataSet.objects.update_or_create(
+            name="council_action_scorecard_total", defaults=self.defaults
+        )
+
+        section_data_set, created = DataSet.objects.update_or_create(
+            name="council_action_scorecard_sections",
+            defaults={
+                **self.defaults,
+                "is_range": True,
+                "label": "Action Scorecards section scores",
+            },
+        )
+
+        total_data_set.areas_available.add(self.get_area_type())
+        section_data_set.areas_available.add(self.get_area_type())
+
+        for name in tqdm(self.data_sets.keys()):
+            if name == "council_action_scorecard_total":
+                data_set = total_data_set
+            else:
+                data_set = section_data_set
+
+            data_type, created = DataType.objects.update_or_create(
+                data_set=data_set,
+                name=name,
+                area_type=self.get_area_type(),
+                defaults={
+                    "data_type": "percent",
+                    "label": self.data_sets[name]["defaults"]["label"],
+                },
+            )
+            self.data_types[name] = data_type
+
+    def get_dataframe(self):
+        df = pd.read_csv(self.data_file)
+        df = filter_authority_type(df, self.area_type, "gss")
+
+        councils = []
+        for index, row in df.iterrows():
+            councils.append(
+                {
+                    "gss_code": row["gss"],
+                    "weighted_total": row["weighted_total"] * 100,
+                    "Buildings & Heating": row["Buildings & Heating"] * 100,
+                    "Transport": row["Transport"] * 100,
+                    "Governance & Finance": row["Governance & Finance"] * 100,
+                    "Biodiversity": row["Biodiversity"] * 100,
+                    "Planning & Land Use": row["Planning & Land Use"] * 100,
+                    "Waste Reduction & Food": row["Waste Reduction & Food"] * 100,
+                    "Collaboration & Engagement": row["Collaboration & Engagement"]
+                    * 100,
+                }
+            )
+
+        df = pd.DataFrame(councils)
+
+        return df

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -475,6 +475,8 @@
               {% for dataset in categories.place %}
                 {% if dataset.is_range and dataset.data|length > 9 %}
                 <div class="card dataset-card area-data--lg {% if dataset.is_favourite or dataset.data.is_favourite %}dataset-card--favourite{% endif %} {% if dataset.featured %} area-data--featured{% endif %}">
+                {% elif dataset.related_category and dataset.related_category.is_range %}
+                <div class="card dataset-card area-data--md {% if dataset.is_favourite or dataset.data.is_favourite %}dataset-card--favourite{% endif %} {% if dataset.featured %} area-data--featured{% endif %}">
                 {% elif dataset.is_range or dataset.data_type == "json" %}
                 <div class="card dataset-card area-data--md {% if dataset.is_favourite or dataset.data.is_favourite %}dataset-card--favourite{% endif %} {% if dataset.featured %} area-data--featured{% endif %}">
                 {% else %}
@@ -502,7 +504,7 @@
                         {% else %}
                           <p class="card-text mb-0 display-6 lh-1 text-primary">{{ dataset.data.value|intcomma }}</p>
                         {% endif %}
-                        {% if dataset.data.average %}
+                        {% if dataset.data.average is not None %}
                           {% if dataset.subcategory == "date" %}
                             <p class="card-text mt-2 text-muted">{{dataset.data.average|floatformat:"0" }} national average</p>
                           {% else %}
@@ -513,34 +515,24 @@
                           {% include 'hub/area/_json_data.html' with dataset=dataset.related_category %}
                         {% endif %}
                       {% elif dataset.is_range and dataset.data|length > 0 %}
-                        <table class="table mb-0 js-chart" data-chart-type="bar" data-chart-direction="y">
-                          <thead>
-                              <tr>
-                                  <th scope="col"></th>
-                                  <th scope="col" data-color="#068670">This area</th>
-                                  <th scope="col" data-color="#ced4da">National average</th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                            {% for row in dataset.data %}
-                              <tr>
-                                <th>
-                                  {{ row.label|html_format_dataset_name|safe }}
-                                </th>
-                                <td>{{ row.value|floatformat }}%</td>
-                                <td>{{ row.average|floatformat }}%</td>
-                              </tr>
-                              {% endfor %}
-                          </tbody>
-                        </table>
+                          {% include 'hub/area/_range_data.html' with dataset=dataset %}
                       {% else %}
                         <p class="card-text mb-0 display-6 lh-1 text-primary">{{ dataset.data.value|floatformat }}%</p>
+                        {% if dataset.data.average is not None %}
                         <p class="card-text mt-2 text-muted">{{dataset.data.average|floatformat }}% national average</p>
+                        {% endif %}
+                        {% if dataset.related_category and dataset.related_category.is_range %}
+                          {% include 'hub/area/_range_data.html' with dataset=dataset.related_category %}
+                        {% endif %}
                       {% endif %}
                     </div>
                     <div class="card-footer">
                       <p class="card-text">
+                        {% if dataset.name.lower == "council climate action scorecard" %}
+                          <a href="{{ dataset.source_url }}councils/{{ slug }}/">{{ dataset.source_name }}</a>
+                        {% else %}
                           <a href="{{ dataset.source_url }}">{{ dataset.source_name }}</a>
+                          {% endif %}
                         {% if dataset.auto_conversion_disclaimer %}
                           <a href="{% url 'future_constituencies' %}">{{ dataset.auto_conversion_disclaimer|safe }}</a>
                         {% endif %}

--- a/hub/templates/hub/area/_range_data.html
+++ b/hub/templates/hub/area/_range_data.html
@@ -1,0 +1,35 @@
+{% load hub_filters %}
+{% if dataset.name.lower == "action scorecards section scores" %}
+<table class="table mb-0 mt-2" data-chart-type="bar" data-chart-direction="y">
+  <tbody>
+    {% for row in dataset.data %}
+      <tr>
+        <th>
+          {{ row.label|html_format_dataset_name|safe }}
+        </th>
+        <td>{{ row.value|floatformat:"0" }}%</td>
+      </tr>
+      {% endfor %}
+  </tbody>
+{% else %}
+<table class="table mb-0 js-chart" data-chart-type="bar" data-chart-direction="y">
+  <thead>
+      <tr>
+          <th scope="col"></th>
+          <th scope="col" data-color="#068670">This area</th>
+          <th scope="col" data-color="#ced4da">National average</th>
+      </tr>
+  </thead>
+  <tbody>
+    {% for row in dataset.data %}
+      <tr>
+        <th>
+          {{ row.label|html_format_dataset_name|safe }}
+        </th>
+        <td>{{ row.value|floatformat }}%</td>
+        <td>{{ row.average|floatformat }}%</td>
+      </tr>
+      {% endfor %}
+  </tbody>
+{% endif %}
+</table>

--- a/hub/views/area.py
+++ b/hub/views/area.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.db.models import Count
 from django.http import Http404, HttpResponsePermanentRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
+from django.utils.text import slugify
 from django.views.generic import DetailView, TemplateView, View
 
 from hub.mixins import TitleMixin
@@ -213,6 +214,8 @@ class AreaView(BaseAreaView):
         if area_type.area_type != "Westminster Constituency":
             context["is_westminster_cons"] = False
 
+        context["slug"] = slugify(self.object.name)
+
         if context["area_type"] == "WMC23":
             context["PPCs"] = [
                 {
@@ -348,6 +351,7 @@ class AreaView(BaseAreaView):
             "power_postcodes_count": "power_postcodes",
             "tcc_open_letter_signatories_count": "tcc_open_letter_signatories",
             "council_net_zero_date": "council_net_zero_details",
+            "council_action_scorecard_total": "council_action_scorecard_sections",
         }
 
         context["is_related_category"] = context["related_categories"].values()


### PR DESCRIPTION
Splits it into two datasets: total and section scores. 
Updates the area template to allow range related datasets.

Fixes #514

<img width="427" alt="Screenshot 2024-04-17 at 14 39 24" src="https://github.com/mysociety/local-intelligence-hub/assets/5310/4949dc53-5301-4072-942f-9b820ec1c1fc">
