### PR TITLE
Show dataset area types on Data Sources page

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -419,10 +419,33 @@ class AreaType(models.Model):
         ("single_tier_council", "Single Tier Council"),
         ("district_council", "District Council"),
     ]
+
+    NAMES_SINGULAR = {
+        "WMC": "current constituency",
+        "WMC23": "future constituency",
+        "STC": "single tier council",
+        "DIS": "district council",
+    }
+
+    NAMES_PLURAL = {
+        "WMC": "current constituencies",
+        "WMC23": "future constituencies",
+        "STC": "single tier councils",
+        "DIS": "district councils",
+    }
+
     name = models.CharField(max_length=50, unique=True)
     code = models.CharField(max_length=10, unique=True)
     area_type = models.CharField(max_length=50, choices=AREA_TYPES)
     description = models.CharField(max_length=300)
+
+    @property
+    def name_singular(self):
+        return self.NAMES_SINGULAR[self.code]
+
+    @property
+    def name_plural(self):
+        return self.NAMES_PLURAL[self.code]
 
     def __str__(self):
         return self.code

--- a/hub/templates/hub/includes/comma.html
+++ b/hub/templates/hub/includes/comma.html
@@ -1,0 +1,1 @@
+{% if not forloop.first %}{% if forloop.last %} and {% else %}, {% endif %}{% endif %}

--- a/hub/templates/hub/sources.html
+++ b/hub/templates/hub/sources.html
@@ -51,6 +51,8 @@
                     <div class="card-footer bg-gray-100">
                         <p class="card-text fs-8 text-muted">
                             <a href="{{ dataset.source }}">{{ dataset.source_label }}</a>
+                            Available for
+                            {% for area_type in dataset.areas_available %}{% include 'hub/includes/comma.html' %}<a href="{% url "explore" %}?area_type={{ area_type.code }}">{{ area_type.name_plural }}</a>{% endfor %}.
                           {% if dataset.release_date %}
                             Updated {{ dataset.release_date }}.
                           {% endif %}

--- a/hub/views/core.py
+++ b/hub/views/core.py
@@ -11,7 +11,7 @@ from mailchimp_marketing.api_client import ApiClientError
 
 from hub.forms import MailingListSignupForm
 from hub.mixins import TitleMixin
-from hub.models import Area, DataSet
+from hub.models import Area, AreaType, DataSet
 
 
 class NotFoundPageView(TitleMixin, TemplateView):
@@ -62,6 +62,11 @@ class SourcesView(TitleMixin, TemplateView):
         }
 
         for dataset in DataSet.objects.all().order_by("label"):
+            # MP datasets are associated with a Person not an Area,
+            # so need to default them to WMC.
+            areas_available = dataset.areas_available.all() or [
+                AreaType.objects.get(code="WMC")
+            ]
             categories[dataset.category or "mp"]["datasets"].append(
                 {
                     "name": dataset.name,
@@ -72,6 +77,7 @@ class SourcesView(TitleMixin, TemplateView):
                     "source_label": dataset.source_label,
                     "release_date": dataset.release_date,
                     "is_public": dataset.is_public,
+                    "areas_available": areas_available,
                 }
             )
 


### PR DESCRIPTION
I got fed up of having to guess which datasets were available in which area types. So now it’s included on the Data Sources page:

<img width="449" alt="Screenshot 2024-04-29 at 17 04 24" src="https://github.com/mysociety/local-intelligence-hub/assets/739624/8ca087c3-4df7-4289-a4e4-292e1397bcae">

Also includes new `name_singular` and `name_plural` properties on the `AreaType` model (which, sadly, we can’t easily use in the one place we want them – explore.js – but hey, maybe they’ll come in useful again later).