### PR TITLE
PersonData party improvements

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -699,6 +699,11 @@ class Person(models.Model):
         area = self.area
         return f"/area/{area.area_type.code}/{area.name}"
 
+    def party(self):
+        return PersonData.objects.get(
+            person=self, data_type=DataType.objects.get(name="party")
+        ).value()
+
     class Meta:
         unique_together = ("external_id", "id_type")
         indexes = [models.Index(fields=["external_id", "id_type"])]

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -176,8 +176,8 @@
                             </div>
                             <div class="flex-grow-1 ms-3">
                                 <h3 class="h4 mb-0 text-primary" id="mp_name">{{ mp.person.name }}</h3>
-                            {% if mp.party %}
-                                <p class="mb-0 text-muted">{{ mp.party }}</p>
+                            {% if mp.person.party %}
+                                <p class="mb-0 text-muted">{{ mp.person.party }}</p>
                             {% endif %}
                             </div>
                         </div>
@@ -364,17 +364,17 @@
             <h2 class="text-primary">Prospective Parliamentary Candidates</h2>
             <p style="max-width: 37em;" class="mb-4">These are the candidates standing for election in this constituency on 4th June.</p>
             <div class="area-data-grid">
-            {% for row in PPCs %}
+            {% for person in PPCs %}
               <div class="card dataset-card area-data--sm area-data--featured">
                   <div class="card-body">
                       <div class="d-flex align-items-center">
                           <div class="flex-shrink-0">
-                              {% include 'hub/includes/person-photo.html' with person=row.person %}
+                              {% include 'hub/includes/person-photo.html' with person=person %}
                           </div>
                           <div class="flex-grow-1 ms-3">
-                              <h3 class="h4 mb-0 text-primary">{{ row.person }}</h3>
-                          {% if row.party %}
-                              <p class="mb-0 text-muted">{{ row.party }}</p>
+                              <h3 class="h4 mb-0 text-primary">{{ person.name }}</h3>
+                          {% if person.party %}
+                              <p class="mb-0 text-muted">{{ person.party }}</p>
                           {% endif %}
                           </div>
                       </div>

--- a/hub/templates/hub/area_search.html
+++ b/hub/templates/hub/area_search.html
@@ -43,13 +43,23 @@
                       {% if area.mp %}
                         <div class="d-flex align-items-center">
                             {% include 'hub/includes/person-photo.html' with person=area.mp width="32" height="32" %}
-                            <p class="mb-0 ms-2 text-muted">{{ area.mp.name|highlight:search }}, MP</p>
+                            <p class="mb-0 ms-2 text-muted">
+                                {{ area.mp.name|highlight:search }}
+                              {% if area.mp.party %}
+                                ({{ area.mp.party }})
+                              {% endif %}
+                            </p>
                         </div>
                       {% elif area.ppcs %}
                         {% for ppc in area.ppcs %}
                         <div class="d-flex align-items-center mt-2">
                             {% include 'hub/includes/person-photo.html' with person=ppc width="32" height="32" %}
-                            <p class="mb-0 ms-2 text-muted">{{ ppc.name|highlight:search }} (PPC)</p>
+                            <p class="mb-0 ms-2 text-muted">
+                                {{ ppc.name|highlight:search }}
+                              {% if ppc.party %}
+                                ({{ ppc.party }})
+                              {% endif %}
+                            </p>
                         </div>
                         {% endfor %}
                       {% endif %}

--- a/hub/views/area.py
+++ b/hub/views/area.py
@@ -217,15 +217,7 @@ class AreaView(BaseAreaView):
         context["slug"] = slugify(self.object.name)
 
         if context["area_type"] == "WMC23":
-            context["PPCs"] = [
-                {
-                    "person": p,
-                    "party": PersonData.objects.get(
-                        person=p, data_type=DataType.objects.get(name="party")
-                    ).value(),
-                }
-                for p in Person.objects.filter(area=self.object, person_type="PPC")
-            ]
+            context["PPCs"] = Person.objects.filter(area=self.object, person_type="PPC")
         try:
             context["mp"] = {
                 "person": Person.objects.get(


### PR DESCRIPTION
An LIH user suggested we show MP and PPC parties on the search results page. Great idea!

While I was there, I realised getting hold of the party outside of the Area page was a bit of a pain, so I’ve suggested some code that adds `party` as a computed field on the `Person` model. Makes it just as easy to get a person’s `party` as it is to get their `name` or `area`. @struan – look ok to you?