### PR TITLE
Lock numpy version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -858,7 +858,7 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "d55465452f145b51116ee271d490d7e39096686f1ead2de7ceb8e143fa799c32"
+content-hash = "41ece93f8b4e11f454166b9a2dfea79c46ec99e832f19f303b160e1c85cf338f"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ beautifulsoup4 = "^4.11.1"
 mailchimp-marketing = {git = "https://github.com/mailchimp/mailchimp-marketing-python.git"}
 geopandas = "^0.14.4"
 pyarrow = "^16.1.0"
+numpy = "1.26.4"
 
 [tool.poetry.dev-dependencies]
 django-debug-toolbar = "^3.7.0"


### PR DESCRIPTION
- Prevent it updating to 2.0.0 - incompatible with pandas but pandas doesn't prevent it
- Should fix tests

https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from