### PR TITLE
Single ruff linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: black Lint
-        uses: psf/black@stable
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          options: "--check --diff"
-          src: "."
-          version: "24.3.0"
-      - name: isort Lint
-        uses: isort/isort-action@master
-      - name: flake8 Lint
-        uses: py-actions/flake8@v2
+          python-version: '3.9' 
+      - name: run ruff linter and formatter
+        run: |
+          pip install ruff==0.4.9
+          ruff check .
+          ruff format . --check

--- a/hub/management/commands/base_importers.py
+++ b/hub/management/commands/base_importers.py
@@ -299,7 +299,7 @@ class BaseImportFromDataFrameCommand(BaseAreaImportCommand):
             self.stdout.write(self.message)
 
         for index, row in tqdm(df.iterrows(), disable=self._quiet, total=df.shape[0]):
-            if type(self.cons_row) is int:
+            if isinstance(self.cons_row, int):
                 cons = row.iloc[self.cons_row]
             else:
                 cons = row[self.cons_row]

--- a/hub/management/commands/base_importers.py
+++ b/hub/management/commands/base_importers.py
@@ -404,7 +404,6 @@ class BaseConstituencyGroupListImportCommand(BaseAreaImportCommand):
     do_not_convert = True
 
     def process_data(self, df: pd.DataFrame):
-
         if not self._quiet:
             self.stdout.write(f"{self.message} ({self.area_type})")
 
@@ -464,7 +463,6 @@ class BaseConstituencyCountImportCommand(BaseAreaImportCommand):
         self.data_type = list(self.data_types.values())[0]
 
     def get_dataframe(self):
-
         if not self.data_file.exists():
             return None
 

--- a/hub/management/commands/import_2024_aid_alliance_power_postcodes.py
+++ b/hub/management/commands/import_2024_aid_alliance_power_postcodes.py
@@ -89,7 +89,6 @@ class Command(MultipleAreaTypesMixin, BaseConstituencyGroupListImportCommand):
         return None
 
     def get_df(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_air_quality_data.py
+++ b/hub/management/commands/import_air_quality_data.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             "pollutant": "NOx",
             "metric": "Annual mean",
             "header_label": "nox2021",
-            "comments": "µg m\u207B\u00B3 (NO\u2093 as NO\u2082)",
+            "comments": "µg m\u207b\u00b3 (NO\u2093 as NO\u2082)",
             "csv_link": "https://uk-air.defra.gov.uk/datastore/pcm/mapnox2021.csv",
         },
         "so_2": {
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             "pollutant": "Ozone",
             "metric": "DGT120",
             "header_label": "dgt12021",
-            "comments": "number of days on which the daily max 8-hr concentration is greater than 120 µg m\u207B\u00B3",
+            "comments": "number of days on which the daily max 8-hr concentration is greater than 120 µg m\u207b\u00b3",
             "csv_link": "https://uk-air.defra.gov.uk/datastore/pcm/mapdgt12021.csv",
         },
         "benzene": {
@@ -155,7 +155,6 @@ class Command(BaseCommand):
         AreaData.objects.filter(data_type__in=self.data_types).delete()
 
     def get_dataframe(self):
-
         if not self.gridcode_lookup_file.exists():
             return None
 

--- a/hub/management/commands/import_brexit_votes.py
+++ b/hub/management/commands/import_brexit_votes.py
@@ -39,7 +39,6 @@ class Command(BaseImportFromDataFrameCommand):
     }
 
     def get_dataframe(self):
-
         if not self.data_file.exists():
             return None
 

--- a/hub/management/commands/import_brexit_votes_new_cons.py
+++ b/hub/management/commands/import_brexit_votes_new_cons.py
@@ -36,7 +36,6 @@ class Command(BaseImportFromDataFrameCommand):
     }
 
     def get_dataframe(self):
-
         if not self.data_file.exists():
             return None
 

--- a/hub/management/commands/import_cen_nzsg_members.py
+++ b/hub/management/commands/import_cen_nzsg_members.py
@@ -16,7 +16,6 @@ class Command(BaseCommand):
         self.import_results()
 
     def get_df(self):
-
         file_loc = Path("data", "cen_nzsg_members.csv")
         if not file_loc.exists():
             return None

--- a/hub/management/commands/import_christian_aid_campaign_organisers.py
+++ b/hub/management/commands/import_christian_aid_campaign_organisers.py
@@ -45,7 +45,6 @@ class Command(BaseImportFromDataFrameCommand):
     }
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_christian_aid_group_locations.py
+++ b/hub/management/commands/import_christian_aid_group_locations.py
@@ -58,7 +58,6 @@ class Command(BaseConstituencyGroupListImportCommand):
     count_data_type = "constituency_christian_aid_group_count"
 
     def get_df(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_council_scorecards_score.py
+++ b/hub/management/commands/import_council_scorecards_score.py
@@ -142,7 +142,6 @@ class Command(MultipleAreaTypesMixin, BaseImportFromDataFrameCommand):
             self.data_types[name] = data_type
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_efpc_fuel_poverty_data.py
+++ b/hub/management/commands/import_efpc_fuel_poverty_data.py
@@ -45,7 +45,6 @@ class Command(BaseImportFromDataFrameCommand):
         ).delete()
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_foe_constituency_reports.py
+++ b/hub/management/commands/import_foe_constituency_reports.py
@@ -40,7 +40,6 @@ class Command(BaseImportFromDataFrameCommand):
         }
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_foe_supporters.py
+++ b/hub/management/commands/import_foe_supporters.py
@@ -56,7 +56,6 @@ class Command(BaseImportFromDataFrameCommand):
     }
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_from_config.py
+++ b/hub/management/commands/import_from_config.py
@@ -182,7 +182,7 @@ class Command(BaseImportFromDataFrameCommand):
             self.stderr.write(f"Unknown file type: {self.file_type}")
             return None
 
-        if type(self.get_cons_col()) != int:
+        if not isinstance(self.get_cons_col(), int):
             df = df.astype({self.get_cons_col(): "str"})
         return df
 
@@ -207,7 +207,6 @@ class Command(BaseImportFromDataFrameCommand):
         *args,
         **options,
     ):
-
         if list_imports:
             self.list_all_imports()
         elif import_name is None:

--- a/hub/management/commands/import_hftf_trained_constituents.py
+++ b/hub/management/commands/import_hftf_trained_constituents.py
@@ -44,7 +44,6 @@ class Command(BaseImportFromDataFrameCommand):
     }
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_hnh_polling_data.py
+++ b/hub/management/commands/import_hnh_polling_data.py
@@ -347,12 +347,10 @@ class Command(BaseImportFromDataFrameCommand):
             self.stdout.write(message)
 
     def extract_and_save_data(self):
-
         self.log(self.message)
 
         area_type = self.get_area_type()
         for file in self.files:
-
             file_loc = settings.BASE_DIR / "data" / file["source_filename"]
 
             if not file_loc.exists():
@@ -435,7 +433,6 @@ class Command(BaseImportFromDataFrameCommand):
     def update_averages(self):
         self.log("Calculating averages for DataTypes:")
         for file in self.files:
-
             file_loc = settings.BASE_DIR / "data" / file["source_filename"]
 
             if not file_loc.exists():
@@ -469,7 +466,6 @@ class Command(BaseImportFromDataFrameCommand):
     def update_max_min(self):
         self.log("Calculating min/max values for DataTypes:")
         for file in self.files:
-
             file_loc = settings.BASE_DIR / "data" / file["source_filename"]
 
             if not file_loc.exists():

--- a/hub/management/commands/import_last_election_data.py
+++ b/hub/management/commands/import_last_election_data.py
@@ -77,7 +77,6 @@ class Command(BaseCommand):
         return AreaType.objects.get(code=self.area_type)
 
     def get_general_election_data(self):
-
         df = pd.read_csv(
             self.general_election_source_file,
         )

--- a/hub/management/commands/import_mp_job_titles.py
+++ b/hub/management/commands/import_mp_job_titles.py
@@ -21,7 +21,6 @@ class Command(BaseCommand):
         return AreaType.objects.get(code="WMC23")
 
     def get_df(self):
-
         if not self.data_file.exists():
             self.stderr.write(f"Data file {self.data_file} does not exist")
             return None
@@ -86,7 +85,6 @@ class Command(BaseCommand):
         PersonData.objects.filter(data_type=data_type).exclude(pk__in=mp_list).delete()
 
     def import_results(self):
-
         df = self.get_df()
 
         if df is None or df.empty:

--- a/hub/management/commands/import_mps_appg_data.py
+++ b/hub/management/commands/import_mps_appg_data.py
@@ -54,7 +54,6 @@ class Command(BaseCommand):
         return df
 
     def get_climate_appgs(self):
-
         climate_appgs_list = Path("data", "climate_APPGs.txt")
 
         if not climate_appgs_list.exists():

--- a/hub/management/commands/import_mps_standing_down_2024.py
+++ b/hub/management/commands/import_mps_standing_down_2024.py
@@ -48,7 +48,6 @@ class Command(BaseCommand):
             return None
 
     def get_df(self):
-
         if not self.data_file.exists():
             self.stderr.write(f"Data file {self.data_file} does not exist")
             return None

--- a/hub/management/commands/import_new_constituencies.py
+++ b/hub/management/commands/import_new_constituencies.py
@@ -1,0 +1,105 @@
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db.utils import IntegrityError
+
+import geopandas as gpd
+import requests
+from mysoc_dataset import get_dataset_df
+from tqdm import tqdm
+
+from hub.models import Area, AreaOverlap, AreaType
+from utils.constituency_mapping import get_overlap_df
+
+
+class Command(BaseCommand):
+    help = "Import basic area information for new constituencies"
+    data_file = settings.BASE_DIR / "data" / "new_constituencies.json"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-q", "--quiet", action="store_true", help="Silence progress bars."
+        )
+
+    def download_constituencies(self):
+        source_file = "https://pages.mysociety.org/2025-constituencies/data/parliament_con_2025/latest/parl_constituencies_2025.parquet"
+        parquet_path = settings.BASE_DIR / "data" / "parl_constituencies_2025.parquet"
+
+        response = requests.get(source_file)
+        with open(parquet_path, "wb") as f:
+            f.write(response.content)
+
+        gdf = gpd.read_parquet(parquet_path)
+
+        # Simplify the geometries
+        gdf["geometry"] = gdf["geometry"].simplify(
+            tolerance=0.001, preserve_topology=True
+        )
+
+        # Save to GeoJSON for import
+        gdf.to_file(self.data_file, driver="GeoJSON")
+
+    def handle(self, quiet: bool = False, *args, **options):
+        if not quiet:
+            print("Importing Areas")
+
+        if not self.data_file.exists():
+            self.download_constituencies()
+
+        with self.data_file.open() as f:
+            cons = json.load(f)
+
+        area_type, created = AreaType.objects.get_or_create(
+            code="WMC23",
+            defaults={
+                "name": "Constituencies at the next election",
+                "area_type": "Westminster Constituency",
+                "description": "Westminster Parliamentary Constituency boundaries, as created by the 2023 Boundary Commission review",
+            },
+        )
+
+        for con in tqdm(cons["features"], disable=quiet):
+            area = con["properties"]
+            try:
+                a, created = Area.objects.get_or_create(
+                    gss=area["gss_code"],
+                    name=area["name"],
+                    area_type=area_type,
+                )
+            except IntegrityError as e:
+                print(f"error creating {area['name']}: {e}")
+                continue
+
+            con["properties"]["PCON13CD"] = area["gss_code"]
+            con["properties"]["type"] = "WMC23"
+            a.geometry = json.dumps(con)
+            a.save()
+
+        constituency_lookup = (
+            get_dataset_df(
+                repo_name="2025-constituencies",
+                package_name="parliament_con_2025",
+                version_name="latest",
+                file_name="parl_constituencies_2025.csv",
+                done_survey=True,
+            )
+            .set_index("short_code")["gss_code"]
+            .to_dict()
+        )
+
+        df = get_overlap_df("PARL10", "PARL25")
+        for area in Area.objects.filter(area_type__code="WMC"):
+            overlap_constituencies = df.query("PARL10 == @area.gss")
+            for _, row in overlap_constituencies.iterrows():
+                new_area = Area.objects.get(
+                    area_type__code="WMC23", gss=constituency_lookup[row["PARL25"]]
+                )
+                AreaOverlap.objects.get_or_create(
+                    area_old=area,
+                    area_new=new_area,
+                    defaults={
+                        "population_overlap": int(row["percentage_overlap_pop"] * 100),
+                        "area_overlap": int(row["percentage_overlap_area"] * 100),
+                    },
+                )

--- a/hub/management/commands/import_nt_property_locations.py
+++ b/hub/management/commands/import_nt_property_locations.py
@@ -81,7 +81,6 @@ class Command(MultipleAreaTypesMixin, BaseAreaImportCommand):
         return pd.read_csv(self.data_file)
 
     def process_data(self, df: pd.DataFrame):
-
         # df.group_name = df.group_name.apply(
         # lambda x: x.split(" | ")[0] if type(x) == str else x
         # )

--- a/hub/management/commands/import_onward_polling_data.py
+++ b/hub/management/commands/import_onward_polling_data.py
@@ -53,7 +53,6 @@ class Command(BaseImportFromDataFrameCommand):
     del data_sets["constituency_cc_high"]["defaults"]["subcategory"]
 
     def get_dataframe(self):
-
         if not self.data_file.exists():
             return None
 

--- a/hub/management/commands/import_red_blue_wall_constituencies.py
+++ b/hub/management/commands/import_red_blue_wall_constituencies.py
@@ -40,7 +40,6 @@ class Command(BaseImportFromDataFrameCommand):
     }
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_rspb_nature_reserves.py
+++ b/hub/management/commands/import_rspb_nature_reserves.py
@@ -70,7 +70,6 @@ class Command(MultipleAreaTypesMixin, BaseConstituencyGroupListImportCommand):
     count_data_type = "rspb_reserves_count"
 
     def get_df(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_tcc_open_letter_signatures.py
+++ b/hub/management/commands/import_tcc_open_letter_signatures.py
@@ -66,7 +66,6 @@ class Command(BaseConstituencyGroupListImportCommand):
     count_data_type = "tcc_open_letter_signatories_count"
 
     def get_df(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_wi_group_locations.py
+++ b/hub/management/commands/import_wi_group_locations.py
@@ -78,7 +78,6 @@ class Command(MultipleAreaTypesMixin, BaseConstituencyGroupListImportCommand):
     count_data_type = "constituency_wi_group_count"
 
     def get_df(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_wildlife_trust_reserves.py
+++ b/hub/management/commands/import_wildlife_trust_reserves.py
@@ -76,7 +76,6 @@ class Command(MultipleAreaTypesMixin, BaseConstituencyGroupListImportCommand):
     }
 
     def get_df(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/hub/management/commands/import_wildlife_trusts_regions.py
+++ b/hub/management/commands/import_wildlife_trusts_regions.py
@@ -39,7 +39,6 @@ class Command(BaseConstituencyGroupListImportCommand):
     group_data_type = "wildlife_trusts_regions"
 
     def get_df(self):
-
         if not self.data_file.exists():
             return None
 

--- a/hub/management/commands/import_wwf_supporters.py
+++ b/hub/management/commands/import_wwf_supporters.py
@@ -39,7 +39,6 @@ class Command(BaseImportFromDataFrameCommand):
     }
 
     def get_dataframe(self):
-
         if self.data_file.exists() is False:
             return None
 

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,7 +22,7 @@ tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "attrs"
-version = "25.2.0"
+version = "25.3.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
@@ -38,7 +38,7 @@ tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.13.3"
+version = "4.13.4"
 description = "Screen-scraping library"
 category = "main"
 optional = false
@@ -56,31 +56,8 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "black"
-version = "24.10.0"
-description = "The uncompromising code formatter."
-category = "dev"
-optional = false
-python-versions = ">=3.9"
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cattrs"
-version = "24.1.2"
+version = "24.1.3"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
@@ -340,19 +317,6 @@ s3 = ["boto3 (>=1.3.1)"]
 test = ["aiohttp", "fiona[s3]", "fsspec", "pytest (>=7)", "pytest-cov", "pytz"]
 
 [[package]]
-name = "flake8"
-version = "5.0.4"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.9.0,<2.10.0"
-pyflakes = ">=2.5.0,<2.6.0"
-
-[[package]]
 name = "geopandas"
 version = "0.14.4"
 description = "Geographic pandas extensions"
@@ -400,17 +364,6 @@ test = ["flufl.flake8", "importlib_resources (>=1.3)", "jaraco.test (>=5.4)", "p
 type = ["pytest-mypy"]
 
 [[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-category = "dev"
-optional = false
-python-versions = ">=3.8.0"
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "libsass"
 version = "0.23.0"
 description = "Sass for Python: A straightforward binding of libsass for Python."
@@ -455,22 +408,6 @@ reference = "HEAD"
 resolved_reference = "3305fa45b3f436767a539c5fba9cb2b0a083d761"
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "mysoc-dataset"
 version = "0.3.0"
 description = "Tool to download mySociety datasets"
@@ -504,7 +441,7 @@ et-xmlfile = "*"
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
@@ -531,14 +468,6 @@ pytz = ">=2020.1"
 test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-category = "dev"
-optional = false
-python-versions = ">=3.8"
-
-[[package]]
 name = "pillow"
 version = "10.4.0"
 description = "Python Imaging Library (Fork)"
@@ -553,19 +482,6 @@ mic = ["olefile"]
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 typing = ["typing-extensions"]
 xmp = ["defusedxml"]
-
-[[package]]
-name = "platformdirs"
-version = "4.3.6"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-category = "dev"
-optional = false
-python-versions = ">=3.8"
-
-[package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "psycopg2"
@@ -585,22 +501,6 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = ">=1.16.6"
-
-[[package]]
-name = "pycodestyle"
-version = "2.9.1"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
-name = "pyflakes"
-version = "2.5.0"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
 
 [[package]]
 name = "pygments"
@@ -645,7 +545,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pytz"
-version = "2025.1"
+version = "2025.2"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -745,6 +645,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "ruff"
+version = "0.4.10"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "shapely"
 version = "2.0.7"
 description = "Manipulation and analysis of geometric objects"
@@ -769,7 +677,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [[package]]
 name = "soupsieve"
-version = "2.6"
+version = "2.7"
 description = "A modern CSS selector implementation for Beautiful Soup."
 category = "main"
 optional = false
@@ -786,14 +694,6 @@ python-versions = ">=3.8"
 [package.extras]
 dev = ["build", "hatch"]
 doc = ["sphinx"]
-
-[[package]]
-name = "tomli"
-version = "2.2.1"
-description = "A lil' TOML parser"
-category = "dev"
-optional = false
-python-versions = ">=3.8"
 
 [[package]]
 name = "tqdm"
@@ -815,7 +715,7 @@ telegram = ["requests"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 category = "main"
 optional = false
@@ -823,7 +723,7 @@ python-versions = ">=3.8"
 
 [[package]]
 name = "tzdata"
-version = "2025.1"
+version = "2025.2"
 description = "Provider of IANA time zone data"
 category = "main"
 optional = false
@@ -831,18 +731,21 @@ python-versions = ">=2"
 
 [[package]]
 name = "url-normalize"
-version = "1.4.3"
+version = "2.2.0"
 description = "URL normalization for Python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.8"
 
 [package.dependencies]
-six = "*"
+idna = ">=3.3"
+
+[package.extras]
+dev = ["mypy", "pre-commit", "pytest", "pytest-cov", "pytest-ruff", "pytest-socket", "ruff", "tox"]
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -873,7 +776,7 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "57c4329224b44670c76bc9958b90119cbf46a4383c8bec69eb81fac11c56e04b"
+content-hash = "dbc7976c372133a70c634ca6635bcf74bd74c1ef830c7b8f2e708e1d732f6b8d"
 
 [metadata.files]
 appdirs = [
@@ -885,40 +788,16 @@ asgiref = [
     {file = "asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"},
 ]
 attrs = [
-    {file = "attrs-25.2.0-py3-none-any.whl", hash = "sha256:611344ff0a5fed735d86d7784610c84f8126b95e549bcad9ff61b4242f2d386b"},
-    {file = "attrs-25.2.0.tar.gz", hash = "sha256:18a06db706db43ac232cce80443fcd9f2500702059ecf53489e3c5a3f417acaf"},
+    {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
+    {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
 ]
 beautifulsoup4 = [
-    {file = "beautifulsoup4-4.13.3-py3-none-any.whl", hash = "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16"},
-    {file = "beautifulsoup4-4.13.3.tar.gz", hash = "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b"},
-]
-black = [
-    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
-    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
-    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
-    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
-    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
-    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
-    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
-    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
-    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
-    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
-    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
-    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
-    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
-    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
-    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
-    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
-    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
-    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
-    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
-    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
-    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
-    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
+    {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
+    {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
 ]
 cattrs = [
-    {file = "cattrs-24.1.2-py3-none-any.whl", hash = "sha256:67c7495b760168d931a10233f979b28dc04daf853b30752246f4f8471c6d68d0"},
-    {file = "cattrs-24.1.2.tar.gz", hash = "sha256:8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85"},
+    {file = "cattrs-24.1.3-py3-none-any.whl", hash = "sha256:adf957dddd26840f27ffbd060a6c4dd3b2192c5b7c2c0525ef1bd8131d8a83f5"},
+    {file = "cattrs-24.1.3.tar.gz", hash = "sha256:981a6ef05875b5bb0c7fb68885546186d306f10f0f6718fe9b96c226e68821ff"},
 ]
 certifi = [
     {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
@@ -1160,10 +1039,6 @@ fiona = [
     {file = "fiona-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:4e82d18acbe55230e9cf8ede2a836d99ea96b7c0cc7d2b8b993e6c9f0ac14dc2"},
     {file = "fiona-1.10.1.tar.gz", hash = "sha256:b00ae357669460c6491caba29c2022ff0acfcbde86a95361ea8ff5cd14a86b68"},
 ]
-flake8 = [
-    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
-    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
-]
 geopandas = [
     {file = "geopandas-0.14.4-py3-none-any.whl", hash = "sha256:3bb6473cb59d51e1a7fe2dbc24a1a063fb0ebdeddf3ce08ddbf8c7ddc99689aa"},
     {file = "geopandas-0.14.4.tar.gz", hash = "sha256:56765be9d58e2c743078085db3bd07dc6be7719f0dbe1dfdc1d705cb80be7c25"},
@@ -1175,10 +1050,6 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e"},
     {file = "importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580"},
-]
-isort = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
 ]
 libsass = [
     {file = "libsass-0.23.0-cp38-abi3-macosx_11_0_x86_64.whl", hash = "sha256:34cae047cbbfc4ffa832a61cbb110f3c95f5471c6170c842d3fed161e40814dc"},
@@ -1284,14 +1155,6 @@ lxml = [
     {file = "lxml-4.9.4.tar.gz", hash = "sha256:b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e"},
 ]
 mailchimp-marketing = []
-mccabe = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-mypy-extensions = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
 mysoc-dataset = [
     {file = "mysoc_dataset-0.3.0-py3-none-any.whl", hash = "sha256:3613f1babec9ead5b3e568b1f0a3faad3f73efe893f0e99b153c858d1d2b67d8"},
     {file = "mysoc_dataset-0.3.0.tar.gz", hash = "sha256:59157721c255dbfd2425c1d70e4f4060caf8e211d6950eec3cbf9f2f7beaef5f"},
@@ -1339,8 +1202,8 @@ openpyxl = [
     {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
 ]
 packaging = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
 pandas = [
     {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406"},
@@ -1370,10 +1233,6 @@ pandas = [
     {file = "pandas-1.5.3-cp39-cp39-win32.whl", hash = "sha256:7cec0bee9f294e5de5bbfc14d0573f65526071029d036b753ee6507d2a21480a"},
     {file = "pandas-1.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:dfd681c5dc216037e0b0a2c821f5ed99ba9f03ebcf119c7dac0e9a7b960b9ec9"},
     {file = "pandas-1.5.3.tar.gz", hash = "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1"},
-]
-pathspec = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 pillow = [
     {file = "pillow-10.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:4d9667937cfa347525b319ae34375c37b9ee6b525440f3ef48542fcf66f2731e"},
@@ -1457,10 +1316,6 @@ pillow = [
     {file = "pillow-10.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cfdd747216947628af7b259d274771d84db2268ca062dd5faf373639d00113a3"},
     {file = "pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06"},
 ]
-platformdirs = [
-    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
-    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
-]
 psycopg2 = [
     {file = "psycopg2-2.9.10-cp310-cp310-win32.whl", hash = "sha256:5df2b672140f95adb453af93a7d669d7a7bf0a56bcd26f1502329166f4a61716"},
     {file = "psycopg2-2.9.10-cp310-cp310-win_amd64.whl", hash = "sha256:c6f7b8561225f9e711a9c47087388a97fdc948211c10a4bccbf0ba68ab7b3b5a"},
@@ -1511,14 +1366,6 @@ pyarrow = [
     {file = "pyarrow-16.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:31a1851751433d89a986616015841977e0a188662fcffd1a5677453f1df2de0a"},
     {file = "pyarrow-16.1.0.tar.gz", hash = "sha256:15fbb22ea96d11f0b5768504a3f961edab25eaf4197c341720c4a387f6c60315"},
 ]
-pycodestyle = [
-    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
-    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
-]
-pyflakes = [
-    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
-    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
-]
 pygments = [
     {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
     {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
@@ -1561,8 +1408,8 @@ python-magic = [
     {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
 ]
 pytz = [
-    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
-    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
+    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
+    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
 ]
 rcssmin = [
     {file = "rcssmin-1.1.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:0101a55992ded00220d38ebaf003d0858c1e6e8b365df6f18f9d7a2cdc5574b3"},
@@ -1678,6 +1525,25 @@ rjsmin = [
     {file = "rjsmin-1.2.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bfbe333dab8d23f0a71da90e2d8e8b762a739cbd55a6f948b2dfda089b6d5853"},
     {file = "rjsmin-1.2.2.tar.gz", hash = "sha256:8c1bcd821143fecf23242012b55e13610840a839cd467b358f16359010d62dae"},
 ]
+ruff = [
+    {file = "ruff-0.4.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c2c4d0859305ac5a16310eec40e4e9a9dec5dcdfbe92697acd99624e8638dac"},
+    {file = "ruff-0.4.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a79489607d1495685cdd911a323a35871abfb7a95d4f98fc6f85e799227ac46e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1dd1681dfa90a41b8376a61af05cc4dc5ff32c8f14f5fe20dba9ff5deb80cd6"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c75c53bb79d71310dc79fb69eb4902fba804a81f374bc86a9b117a8d077a1784"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18238c80ee3d9100d3535d8eb15a59c4a0753b45cc55f8bf38f38d6a597b9739"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d8f71885bce242da344989cae08e263de29752f094233f932d4f5cfb4ef36a81"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:330421543bd3222cdfec481e8ff3460e8702ed1e58b494cf9d9e4bf90db52b9d"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e9b6fb3a37b772628415b00c4fc892f97954275394ed611056a4b8a2631365e"},
+    {file = "ruff-0.4.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f54c481b39a762d48f64d97351048e842861c6662d63ec599f67d515cb417f6"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:67fe086b433b965c22de0b4259ddfe6fa541c95bf418499bedb9ad5fb8d1c631"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:acfaaab59543382085f9eb51f8e87bac26bf96b164839955f244d07125a982ef"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3cea07079962b2941244191569cf3a05541477286f5cafea638cd3aa94b56815"},
+    {file = "ruff-0.4.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:338a64ef0748f8c3a80d7f05785930f7965d71ca260904a9321d13be24b79695"},
+    {file = "ruff-0.4.10-py3-none-win32.whl", hash = "sha256:ffe3cd2f89cb54561c62e5fa20e8f182c0a444934bf430515a4b422f1ab7b7ca"},
+    {file = "ruff-0.4.10-py3-none-win_amd64.whl", hash = "sha256:67f67cef43c55ffc8cc59e8e0b97e9e60b4837c8f21e8ab5ffd5d66e196e25f7"},
+    {file = "ruff-0.4.10-py3-none-win_arm64.whl", hash = "sha256:dd1fcee327c20addac7916ca4e2653fbbf2e8388d8a6477ce5b4e986b68ae6c0"},
+    {file = "ruff-0.4.10.tar.gz", hash = "sha256:3aa4f2bc388a30d346c56524f7cacca85945ba124945fe489952aadb6b5cd804"},
+]
 shapely = [
     {file = "shapely-2.0.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:33fb10e50b16113714ae40adccf7670379e9ccf5b7a41d0002046ba2b8f0f691"},
     {file = "shapely-2.0.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f44eda8bd7a4bccb0f281264b34bf3518d8c4c9a8ffe69a1a05dabf6e8461147"},
@@ -1727,66 +1593,32 @@ six = [
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 soupsieve = [
-    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
-    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
+    {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
+    {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
 ]
 sqlparse = [
     {file = "sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"},
     {file = "sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"},
-]
-tomli = [
-    {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
-    {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee"},
-    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106"},
-    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8"},
-    {file = "tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff"},
-    {file = "tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"},
-    {file = "tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"},
-    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"},
-    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"},
-    {file = "tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98"},
-    {file = "tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"},
-    {file = "tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281"},
-    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2"},
-    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744"},
-    {file = "tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec"},
-    {file = "tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69"},
-    {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
-    {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
 tqdm = [
     {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
     {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 tzdata = [
-    {file = "tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"},
-    {file = "tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694"},
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
 url-normalize = [
-    {file = "url-normalize-1.4.3.tar.gz", hash = "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2"},
-    {file = "url_normalize-1.4.3-py2.py3-none-any.whl", hash = "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed"},
+    {file = "url_normalize-2.2.0-py3-none-any.whl", hash = "sha256:3fe387b62f5b66db94304bc703bf6d34de52aaa9590d4d1f1bbdf305a1430064"},
+    {file = "url_normalize-2.2.0.tar.gz", hash = "sha256:0f0b7cc95a95d2d9b0c9a51d47a326559bc05bd1558accdada21bb0c9504de85"},
 ]
 urllib3 = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
+    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
 zipp = [
     {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,19 +29,43 @@ numpy = "1.26.4"
 
 [tool.poetry.dev-dependencies]
 django-debug-toolbar = "^3.7.0"
-black = "^24.3.0"
 coverage = "^6.5.0"
-flake8 = "^5.0.4"
-isort = "^5.10.1"
+
+[tool.poetry.group.dev.dependencies]
+ruff = "^0.4.9"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.isort]
-profile = "black"
-default_section = "THIRDPARTY"
-known_first_party = "hub"
-known_django = "django"
-sections = ["FUTURE", "STDLIB", "DJANGO", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
-extend_skip = ["migrations"]
+
+[tool.ruff]
+extend-exclude = ["migrations"]
+
+[tool.ruff.lint]
+select = [
+    "E",
+    # flake8
+    "F",
+    # isort
+    "I",
+]
+ignore = [
+    # line too long, sorted with formatter where it can be
+    "E501", 
+]
+
+
+[tool.ruff.lint.isort]
+known-first-party = ["hub"]
+section-order = [
+  "future",
+  "standard-library",
+  "django",
+  "third-party",
+  "first-party",
+  "local-folder"
+]
+
+[tool.ruff.lint.isort.sections]
+django = ["django"]

--- a/script/lint
+++ b/script/lint
@@ -5,6 +5,5 @@
 # check that we are in the expected directory
 cd `dirname $0`/..
 
-script/dev-command black .
-script/dev-command isort .
-script/dev-command flake8 --exclude ".venv" .
+script/dev-command ruff check . --fix
+script/dev-command ruff format  .


### PR DESCRIPTION
Quick experiment - not essential to anything but a test of how easily ruff fits an existing project.

This PR replaces black, isort and flake8 with [ruff](https://astral.sh/ruff) - with config settings to mirror the current isort settings. 

Linting differences are mostly blank lines (annoying some of which I introduced the reverse with black the other day) - one instance where it changes /B to /b - generally ruff follows black closely. 

The advantage of it (apart from condensing a few packages) is it's very very quick. Noticeably much faster than running black even on a smallish project like this - which is nice when running something that formats on save.