### PR TITLE
Fix Leaflet marker image path discovery

### DIFF
--- a/hub/static/css/_leaflet.scss
+++ b/hub/static/css/_leaflet.scss
@@ -1,4 +1,0 @@
-.leaflet-default-icon-path {
-    // L.Icon.Default uses this style to work out the path to our images.
-    background-image: url("/static/leaflet/images/marker-icon.png") !important;
-}

--- a/hub/static/css/main.scss
+++ b/hub/static/css/main.scss
@@ -47,7 +47,6 @@
 
 @import "../../../vendor/leaflet/leaflet-1.8.0";
 
-@import "leaflet";
 @import "leaflet-geosearch";
 
 @import "site-header";

--- a/hub/templates/hub/explore.html
+++ b/hub/templates/hub/explore.html
@@ -7,6 +7,17 @@
 {% block script %}
     <script type="module" src="{% static 'js/home-out-esm.js' %}"></script>
     <script type="module" src="{% static 'js/explore-out-esm.js' %}"></script>
+    <style type="text/css">
+        {% comment %}
+            L.Icon.Default uses this style to work out the path to our images.
+            We define it here, rather than in our Sass pipeline, to bypass
+            django-compressor’s URL hashing, which is incompatible with the
+            regular expression used in Leaflet.Icon.Default._stripUrl.
+        {% endcomment %}
+        .leaflet-default-icon-path {
+            background-image: url("{% static 'leaflet/images/marker-icon.png' %}") !important;
+        }
+    </style>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Including `url("/static/leaflet/images/marker-icon.png")` in our Sass doesn’t work because django-compressor adds a hash as a query parameter, which breaks Leaflet’s `/^(.*)marker-icon\.png$/` regexp.

So this commit removes the ruleset from our Sass pipeline, and just embeds it directly into the HTML page, where django-compressor can’t mess it up.