### PR TITLE
don't return new modal dialogs if they're already defined

### DIFF
--- a/hub/static/js/explore.esm.js
+++ b/hub/static/js/explore.esm.js
@@ -62,9 +62,15 @@ const app = createApp({
   },
   computed: {
     datasetModal() {
+      if (this.datasetModal) {
+        return this.datasetModal
+      }
       return new Modal(this.$refs.datasetModal)
     },
     areaTypeModal() {
+      if (this.areaTypeModal) {
+        return this.areaTypeModal
+      }
       return new Modal(this.$refs.areaTypeModal)
     },
     selectableDatasets() {


### PR DESCRIPTION
In theory I think vue should keep track of this but there's some sort of interaction that happens which means it can lose track of the dialog which means that e.g dialog.hide() does not work. To avoid this check for an existing dialog and return that if so then return that, otherwise create a new one.