### PR TITLE
Added overflow hidden to dataset-card

### DIFF
--- a/hub/static/css/_dataset-card.scss
+++ b/hub/static/css/_dataset-card.scss
@@ -1,4 +1,7 @@
 .dataset-card {
+    // This prevents some odd overflow horizontal behaviour when there are graphs present on mobile.
+    overflow: hidden;
+
     .js-favourite-this-dataset {
         display: block;
     }


### PR DESCRIPTION
Working on another ticket I noticed an odd horizontal overflowing when you are on mobile. After some playing around I realised that it only happens when there is a graph.

Fixes:

https://github.com/user-attachments/assets/dfdf2ffa-b493-4c41-8ea4-ede5ca51395b

