### PR TITLE
Add generator and import script for TCC Common Grounds 2024 pledges

### DIFF
--- a/hub/management/commands/base_generators.py
+++ b/hub/management/commands/base_generators.py
@@ -166,7 +166,7 @@ class BaseLatLonGeneratorCommand(BaseCommand):
             "-i", "--ignore", action="store_true", help="Ignore existing data file"
         )
 
-    def _setup(self):
+    def _setup(self, *args, **kwargs):
         pass
 
     def handle(self, quiet=False, ignore=False, *args, **options):

--- a/hub/management/commands/generate_tcc_common_grounds_2024_pledges.py
+++ b/hub/management/commands/generate_tcc_common_grounds_2024_pledges.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+
+import pandas as pd
+
+from .base_generators import BaseLatLonGeneratorCommand
+
+
+class Command(BaseLatLonGeneratorCommand):
+    help = "Generate CSV file of pledges to take part in TCC’s 2024 Common Grounds Day of Action"
+    message = "Generating a CSV of pledges to take part in TCC’s 2024 Common Grounds Day of Action"
+
+    data_file = settings.BASE_DIR / "data" / "tcc_common_grounds_2024_pledges.csv"
+    out_file = (
+        settings.BASE_DIR / "data" / "tcc_common_grounds_2024_pledges_processed.csv"
+    )
+
+    row_name = "postcode"
+    uses_gss = True
+    uses_postcodes = True
+
+    def get_dataframe(self):
+        df = pd.read_csv(self.data_file, usecols=["POSTCODE"])
+        df.columns = ["postcode"]
+        return df
+
+    def get_location_from_row(self, row):
+        return {"postcode": row.postcode}

--- a/hub/management/commands/import_tcc_common_grounds_2024_pledges.py
+++ b/hub/management/commands/import_tcc_common_grounds_2024_pledges.py
@@ -1,0 +1,52 @@
+from django.conf import settings
+
+from hub.models import AreaData, DataSet
+
+from .base_importers import BaseConstituencyCountImportCommand, MultipleAreaTypesMixin
+
+
+class Command(MultipleAreaTypesMixin, BaseConstituencyCountImportCommand):
+    help = "Import pledges to take part in TCC’s 2024 Common Grounds Day of Action"
+
+    message = (
+        "importing pledges to take part in TCC’s 2024 Common Grounds Day of Action"
+    )
+    uses_gss = True
+    cons_col = "gss"
+    data_file = (
+        settings.BASE_DIR / "data" / "tcc_common_grounds_2024_pledges_processed.csv"
+    )
+
+    area_types = ["WMC", "WMC23", "STC", "DIS"]
+    cons_col_map = {
+        "WMC": "WMC",
+        "WMC23": "WMC23",
+        "STC": "STC",
+        "DIS": "DIS",
+    }
+
+    defaults = {
+        "label": "Constituents pledged to meet MP as part of Common Grounds 2024",
+        "data_type": "integer",
+        "category": "movement",
+        "release_date": "October 2024",
+        "source_label": "Data from The Climate Coalition.",
+        "source": "https://peopleclimatenature.org/",
+        "source_type": "csv",
+        "data_url": "",
+        "table": "areadata",
+        "default_value": 10,
+        "comparators": DataSet.numerical_comparators(),
+        "unit_type": "raw",
+        "unit_distribution": "people_in_area",
+    }
+
+    data_sets = {
+        "tcc_common_grounds_2024_pledges": {
+            "defaults": defaults,
+        },
+    }
+
+    def delete_data(self):
+        for data_type in self.data_types.values():
+            AreaData.objects.filter(data_type=data_type).delete()


### PR DESCRIPTION
TCC asked me for this data, but weren’t sure whether they could make it public. I figured it was no more effort to write it up as a proper data import (then give them the data they wanted, via `/explore` in my local dev environment) and then, if/when they agree the data can be public, we can merge and deploy this.

I have the `tcc_common_grounds_2024_pledges.csv` file on my Mac. (It’s a CSV with a single column of postcodes, titled `POSTCODE`.)