### PR TITLE
'Act Now Change Forever' Top banner

### DIFF
--- a/hub/static/css/_act-now-banner.scss
+++ b/hub/static/css/_act-now-banner.scss
@@ -1,6 +1,8 @@
 .act-now-banner {
     position: relative;
     background: #ffc9ef;
+    border-radius: $border-radius;
+    overflow: hidden;
 
     display: flex;
     flex-direction: column;

--- a/hub/static/css/_act-now-banner.scss
+++ b/hub/static/css/_act-now-banner.scss
@@ -66,3 +66,31 @@
         }
     }
 }
+
+.act-now-cta-bar {
+    // Colours come from https://assets.nationbuilder.com/tcc/pages/2383/features/original/3_New.png?1750238318%27)
+    --bs-primary-rgb: 22, 15, 61; // Navy Blue
+    --bs-secondary-rgb: 0, 167, 125; // Green
+    --bs-warning-rgb: 252, 235, 0; // Yellow
+    
+    .container {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+    
+    &__heading {
+        text-transform: uppercase;
+        margin-bottom: 0;
+    }
+    
+    @include media-breakpoint-up(lg) {
+        .container {
+            display: flex;
+            flex-direction: row;
+            justify-content: center;
+            align-items: center;
+        }
+    }
+}

--- a/hub/templates/hub/area.html
+++ b/hub/templates/hub/area.html
@@ -13,6 +13,10 @@
 
 {% block content %}
 
+{% if foe_act_now_dataset %}
+{% include "hub/area/action_templates/_act_now_bar.html" with foe_act_now_dataset=foe_act_now_dataset %}
+{% endif %}
+
 <div class="py-4 py-lg-5">
     <div class="container">
         <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">

--- a/hub/templates/hub/area/action_templates/_act_now_bar.html
+++ b/hub/templates/hub/area/action_templates/_act_now_bar.html
@@ -1,0 +1,21 @@
+<div class="act-now-cta-bar position-sticky top-0 py-3 bg-primary text-light" style="z-index: 1;" role="banner">
+
+  <div class="container">
+    <h2 id="cta-heading" class="act-now-cta-bar__heading fs-6">
+        <span>act </span>
+        <span class="text-warning">now </span>
+        <span>change </span>
+        <span class="text-secondary">forever</span>
+    </h2>
+
+    <p class="act-now-cta-bar__description mb-0">
+        <span class="d-none d-lg-inline-block fs-8 me-2" aria-hidden="true">&#9679;</span>
+        Check {{ area.name }}’s constituency briefing
+    </p>
+
+    <a class="act-now-cta-bar__button btn btn-light btn-sm text-nowrap d-inline-flex align-items-center gap-1" href="{{ foe_act_now_dataset.data.value.url|safe }}" target="_blank" rel="noopener noreferrer" aria-describedby="cta-heading">
+        {% include 'hub/includes/icons/download.html' %}
+        <span>Download PDF</span>
+    </a>
+  </div>
+</div>

--- a/hub/views/area.py
+++ b/hub/views/area.py
@@ -367,6 +367,10 @@ class AreaView(BaseAreaView):
 
                 indexed_categories[data["db_name"]] = data
 
+                # TODO: Remove this after 9th July 2025
+                if data_set.name == 'foe_act_now':
+                    context['foe_act_now_dataset'] = data
+
         context["related_categories"] = {
             "constituency_christian_aid_group_count": "constituency_christian_aid_groups",
             "constituency_foe_groups_count": "constituency_foe_groups",


### PR DESCRIPTION
Preview:

https://github.com/user-attachments/assets/64964649-7553-4308-8904-b2546d48bdbd

I agree that adding a link to the PDF on the current banner, will compete with all the information we already have there. I thought adding this sticky banner would be better; it's noticeable enough thanks to the navy background (I got the colours from the ANCF infographic), and it doesn't clash with the colours we currently use.

I thought of a second approach, to add a sticky button at the bottom of the page that takes you to the pink ACNF card, but then I wondered if the button would give enough context for people to really click on it, only to be taken to the card and then click again to download the PDF.

Please note: Currently `_act_now_bar.html` is being always included on the `area.html` I haven't done the work for the backend.