### PR TITLE
Add import config for More In Common June 2025 social connection MRP

### DIFF
--- a/conf/imports.json
+++ b/conf/imports.json
@@ -1858,5 +1858,43 @@
         "data_col":"Other"
       }
     ]
+  },
+  {
+    "name": "more_in_common_connection",
+    "label": "Perceived connection to society",
+    "description": "In this MRP poll, respondents were asked whether they felt disconnected or connected to the society around them, and the results mapped to each constituency in Great Britain. Negative values indicate an area where social connection is likely to be low, and positive numbers, high.",
+    "data_type": "percent",
+    "multiply_percentage": true,
+    "is_range": false,
+    "category": "opinion",
+    "subcategory": null,
+    "release_date": "June 2025",
+    "source_label": "MRP polling from More In Common, in partnership with the UCL Policy Lab and Citizens UK.",
+    "source": "https://www.moreincommon.org.uk/latest-insights/this-place-matters-a-social-connection-map-of-britain/",
+    "source_type": "csv",
+    "data_url": null,
+    "table": "areadata",
+    "default_value": 0,
+    "comparators": "numerical",
+    "exclude_countries":["Northern Ireland"],
+    "unit_type": "percentage",
+    "unit_distribution": "people_in_area",
+    "fill_blanks": true,
+    "is_public": true,
+    "is_filterable": true,
+    "is_shadeable": true,
+    "data_file": "more_in_common_june_2025_connection_mrp.csv",
+    "uses_gss": false,
+    "delete_first": true,
+    "file_type": "csv",
+    "area_type": "WMC23",
+    "data_types": [
+      {
+        "name": "more_in_common_connection",
+        "label": "Perceived connection to society",
+        "constituency_col": "wmc23_name",
+        "data_col": "value"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Imports the data from [More In Common’s June 2025 MRP polling on social connection](https://www.moreincommon.org.uk/latest-insights/this-place-matters-a-social-connection-map-of-britain/) (which they published a few days ago).

@struan let me know when you get round to reviewing this, and I’ll send you the `more_in_common_june_2025_connection_mrp.csv`.

I noticed the combination of `"data_type": "percent"` and `"multiply_percentage": true` can result in messy float handling (`AreaData.float` values like `29.000000000001` or `28.9999999999998` etc). I spent a little while trying to work out whether I could prevent this (perhaps by setting a different `data_type` in the config) but didn’t get anywhere. I assume this is a problem for _all_ float-type data we store, and it’s just exacerbated by `import_from_config` conflating "this should be presented as a percentage in the front end" and "this should be stored as a float rather than an integer", and by the multiplication that `multiply_percentage` does. Any ideas on how we can avoid this?

(It’d be nice to also remove the `round(…, 1)` from `FilterMixin.format_value` at the same time, since that’s just a sticking plaster on the same problem, but I guess it’s not essential.)

Oh, and also, my `"default_value": 0` doesn’t seem to have any effect – when you add the dataset as a filter on the Explore page, the text input is set to `-1` (the average value) by default, rather than `0`. Bug?