### PR TITLE
Add import config for Feb 2024 ECIU Net Zero economy data

### DIFF
--- a/conf/imports.json
+++ b/conf/imports.json
@@ -1858,5 +1858,72 @@
         "data_col":"Other"
       }
     ]
+  },
+  {
+    "name": "eciu_net_zero_economy",
+    "label": null,
+    "description": null,
+    "data_type": null,
+    "is_range": false,
+    "category": "place",
+    "subcategory": null,
+    "release_date": "February 2024",
+    "source_label": "Analysis by CBI Economics and The Data City, commissioned by the Energy & Climate Intelligence Unit (ECIU).",
+    "source": "https://eciu.net/analysis/reports/2024/the-uks-net-zero-economy-2024",
+    "source_type": "xlsx",
+    "data_url": null,
+    "table": "areadata",
+    "default_value": 0,
+    "comparators": "numerical",
+    "exclude_countries":["Northern Ireland"],
+    "unit_type": null,
+    "unit_distribution": "people_in_area",
+    "fill_blanks": true,
+    "is_public": true,
+    "is_filterable": true,
+    "is_shadeable": true,
+    "data_file": "ECIU CBI Data City net zero economy February 2024.xlsx",
+    "uses_gss": false,
+    "delete_first": true,
+    "file_type": "excel",
+    "area_type": "WMC23",
+    "data_types": [
+      {
+        "name": "eciu_net_zero_gva",
+        "label": "Economic value added by net zero businesses (£ million)",
+        "description": "Estimated Gross Value Added by businesses involved in the Net Zero economy, in this constituency, in 2022–2023.",
+        "data_type": "integer",
+        "unit_type": "integer",
+        "constituency_col": "constituency name",
+        "data_col": "gva absolute (£m)"
+      },
+      {
+        "name": "eciu_net_zero_gva_proportion",
+        "label": "Proportion of local economic value added by net zero businesses",
+        "description": "Estimated Gross Value Added by businesses involved in the Net Zero economy, in this constituency, in 2022–2023, as a proportion of total GVA.",
+        "data_type": "percent",
+        "unit_type": "percentage",
+        "constituency_col": "constituency name",
+        "data_col": "gva percent"
+      },
+      {
+        "name": "eciu_net_zero_jobs",
+        "label": "Total number of jobs related to the Net Zero economy",
+        "description": "Estimated number of jobs involved in the Net Zero economy, in this constituency, in 2022–2023.",
+        "data_type": "integer",
+        "unit_type": "integer",
+        "constituency_col": "constituency name",
+        "data_col": "jobs absolute"
+      },
+      {
+        "name": "eciu_net_zero_jobs_proportion",
+        "label": "Proportion of jobs related to the Net Zero economy",
+        "description": "Estimated number of jobs involved in the Net Zero economy, in this constituency, in 2022–2023, as a proportion of all jobs.",
+        "data_type": "percent",
+        "unit_type": "percentage",
+        "constituency_col": "constituency name",
+        "data_col": "jobs percent"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Data from https://eciu.net/analysis/reports/2024/the-uks-net-zero-economy-2024, inspired by conversations with Uplift UK, and participants at the recent TCC/Green Alliance event.

The Gross Value Add figures are massively skewed by City of London (where the inclusion of financial services as part of the "green economy" means that the City’s financial value outshines literally everything else in the UK by orders of magnitude. Not sure how useful this particular dataset will be, at least as a UK-wide shader on the Explore page, or for the City of London page specifically.

This got me wondering whether there’s a better way to handle outliers like this (eg: [the source page](https://eciu.net/analysis/reports/2024/the-uks-net-zero-economy-2024) from ECIU ranks the constituencies into quintiles, collapsing the massive gulf between the City of London and all the other constituencies.

But that’s probably something we could revisit in future. I think this new dataset is probably useful enough to publish as-is.