### PR TITLE
Correctly handle DataTypes provided in Explore page URL state

### DIFF
--- a/hub/mixins.py
+++ b/hub/mixins.py
@@ -77,6 +77,7 @@ class FilterMixin:
                         "comparator": comparator,
                         "value": value,
                         "value_col": dataset.value_col,
+                        "header_label": dataset.label,
                     }
                 )
             except DataSet.DoesNotExist:  # pragma: nocover
@@ -95,6 +96,7 @@ class FilterMixin:
                             "comparator": comparator,
                             "value": value,
                             "value_col": datatype.value_col,
+                            "header_label": f"{datatype.data_set.label} - {datatype.label}",
                         }
                     )
                 except DataType.DoesNotExist:  # pragma: nocover
@@ -196,7 +198,7 @@ class FilterMixin:
         area_type = self.area_type()
 
         headers = [f"{area_type.short_name_singular} name".capitalize()]
-        headers += map(lambda f: f["dataset"].label, self.filters())
+        headers += map(lambda f: f.get("header_label", f["label"]), self.filters())
         headers += map(
             lambda f: f.get("header_label", f["label"]), self.columns(mp_name=mp_name)
         )

--- a/hub/static/js/explore.esm.js
+++ b/hub/static/js/explore.esm.js
@@ -357,7 +357,9 @@ const app = createApp({
         if (key == 'view' ) {
           this.view = v;
         } else if (key == 'shader') {
-          pending[v] = () => { this.addShader(v) }
+          // append _shader to avoid key overlap if filtering and shading with
+          // the same dataset/type
+          pending[v + "_shader"] = () => { this.addShader(v) }
         } else if (key == 'columns') {
           pending[v] = () => { for (const col of v.split(',')) { this.addColumn(col) } }
         } else if (key == 'area_type') {

--- a/hub/static/js/explore.esm.js
+++ b/hub/static/js/explore.esm.js
@@ -218,10 +218,19 @@ const app = createApp({
         Object.keys(dataset.comparators)[0]
       dataset.selectedValue = current.value || dataset.defaultValue
 
+      // They requested a DataType, so we want to select that.
+      // It must be in `dataset.types` because otherwise `getDataset`
+      // wouldn’t have returned this DataSet.
+      if (dataset.name !== datasetName) {
+        dataset.selectedType = datasetName
+      }
+
       if (!dataset.selectedValue && dataset.options) {
         dataset.selectedValue = dataset.options[0]
       }
 
+      // They requested a DataSet with DataTypes, but didn’t
+      // pick a type. Default to the first DataType.
       if (!dataset.selectedType && dataset.types) {
         dataset.selectedType = dataset.types[0].name
       }


### PR DESCRIPTION
It appears we had a bug, where a DataType provided in the URL state (Eg: `/explore/?hnh_mrp_24-3_very_likely__gte=12`) would result in a different DataType of that DataSet (perhaps just the first child DataType in the datasets.json?) being requested from the ExploreJSON or ExploreCSV endpoints.

`addFilter()` now plucks the correct DataType out of the DataSet returned by `getDataset()`, if that’s what the user requested.

I am mystified as to why this doesn’t affect `addColumn()` and `addShader()` as well, but in testing, they both seem to correctly pull out just the requested DataType. I must be missing something.

I also fixed our FiterMixin on the server side, to correctly append the requested DataType name to the end of the column header, when a DataType was requested via the ExploreJSON or ExploreCSV endpoints.